### PR TITLE
Add unit tests to ridership app

### DIFF
--- a/src/components/DateRangeSelector.test.tsx
+++ b/src/components/DateRangeSelector.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DateRangeSelector from './DateRangeSelector';
+import { daysOfWeek } from '../hooks/useUserDashboardInput';
+
+const defaultProps = {
+  startDate: new Date(2020, 6), // July 2020
+  setStartDate: vi.fn(),
+  endDate: new Date(2025, 6), // July 2025
+  setEndDate: vi.fn(),
+  dayOfWeek: daysOfWeek.Weekday,
+  setDayOfWeek: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('DateRangeSelector rendering', () => {
+  it('renders the Start fieldset legend', () => {
+    render(<DateRangeSelector {...defaultProps} />);
+    expect(screen.getByText('Start')).toBeTruthy();
+  });
+
+  it('renders the End fieldset legend', () => {
+    render(<DateRangeSelector {...defaultProps} />);
+    expect(screen.getByText('End')).toBeTruthy();
+  });
+
+  it('renders the Day of Week fieldset legend', () => {
+    render(<DateRangeSelector {...defaultProps} />);
+    expect(screen.getByText('Day of Week')).toBeTruthy();
+  });
+
+  it('renders Weekday, Saturday, and Sunday labels', () => {
+    render(<DateRangeSelector {...defaultProps} />);
+    expect(screen.getByText('Weekday')).toBeTruthy();
+    expect(screen.getByText('Saturday')).toBeTruthy();
+    expect(screen.getByText('Sunday')).toBeTruthy();
+  });
+
+  it('renders four dropdowns (start month, start year, end month, end year)', () => {
+    render(<DateRangeSelector {...defaultProps} />);
+    expect(screen.getAllByRole('combobox')).toHaveLength(4);
+  });
+
+  it('shows the correct start month (July = index 6)', () => {
+    render(<DateRangeSelector {...defaultProps} />);
+    const selects = screen.getAllByRole('combobox');
+    expect(Number((selects[0] as HTMLSelectElement).value)).toBe(6);
+  });
+
+  it('shows the correct start year', () => {
+    render(<DateRangeSelector {...defaultProps} />);
+    const selects = screen.getAllByRole('combobox');
+    expect(Number((selects[1] as HTMLSelectElement).value)).toBe(2020);
+  });
+
+  it('shows the correct end month', () => {
+    render(<DateRangeSelector {...defaultProps} />);
+    const selects = screen.getAllByRole('combobox');
+    expect(Number((selects[2] as HTMLSelectElement).value)).toBe(6);
+  });
+
+  it('shows the correct end year', () => {
+    render(<DateRangeSelector {...defaultProps} />);
+    const selects = screen.getAllByRole('combobox');
+    expect(Number((selects[3] as HTMLSelectElement).value)).toBe(2025);
+  });
+});
+
+describe('DateRangeSelector interactions', () => {
+  it('calls setStartDate when the start month changes', () => {
+    const setStartDate = vi.fn();
+    render(<DateRangeSelector {...defaultProps} setStartDate={setStartDate} />);
+    const [startMonth] = screen.getAllByRole('combobox');
+    fireEvent.change(startMonth, { target: { value: '3' } });
+    expect(setStartDate).toHaveBeenCalledOnce();
+  });
+
+  it('calls setStartDate when the start year changes', () => {
+    const setStartDate = vi.fn();
+    render(<DateRangeSelector {...defaultProps} setStartDate={setStartDate} />);
+    const [, startYear] = screen.getAllByRole('combobox');
+    fireEvent.change(startYear, { target: { value: '2021' } });
+    expect(setStartDate).toHaveBeenCalledOnce();
+  });
+
+  it('calls setEndDate when the end month changes', () => {
+    const setEndDate = vi.fn();
+    render(<DateRangeSelector {...defaultProps} setEndDate={setEndDate} />);
+    const [, , endMonth] = screen.getAllByRole('combobox');
+    fireEvent.change(endMonth, { target: { value: '11' } });
+    expect(setEndDate).toHaveBeenCalledOnce();
+  });
+
+  it('calls setEndDate when the end year changes', () => {
+    const setEndDate = vi.fn();
+    render(<DateRangeSelector {...defaultProps} setEndDate={setEndDate} />);
+    const [, , , endYear] = screen.getAllByRole('combobox');
+    fireEvent.change(endYear, { target: { value: '2024' } });
+    expect(setEndDate).toHaveBeenCalledOnce();
+  });
+
+  it('calls setDayOfWeek when a day-of-week radio button is clicked', () => {
+    const setDayOfWeek = vi.fn();
+    render(<DateRangeSelector {...defaultProps} setDayOfWeek={setDayOfWeek} />);
+    fireEvent.click(screen.getByText('Saturday'));
+    expect(setDayOfWeek).toHaveBeenCalled();
+  });
+});

--- a/src/components/LineFilters.test.tsx
+++ b/src/components/LineFilters.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import LineFilters from './LineFilters';
+
+const defaultProps = {
+  searchText: '',
+  setSearchText: vi.fn(),
+  modes: ['bus', 'train'],
+  setModes: vi.fn(),
+  clearSelections: vi.fn(),
+  selectAllVisibleLines: vi.fn(),
+  isAggregateVisible: false,
+  toggleIsAggregateVisible: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('LineFilters rendering', () => {
+  it('renders the search input with placeholder', () => {
+    render(<LineFilters {...defaultProps} />);
+    expect(screen.getByPlaceholderText('Search lines')).toBeTruthy();
+  });
+
+  it('displays the current search text', () => {
+    render(<LineFilters {...defaultProps} searchText="silver" />);
+    expect(screen.getByDisplayValue('silver')).toBeTruthy();
+  });
+
+  it('renders the Select All button', () => {
+    render(<LineFilters {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Select All' })).toBeTruthy();
+  });
+
+  it('renders the Clear All button', () => {
+    render(<LineFilters {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Clear All' })).toBeTruthy();
+  });
+
+  it('renders the Aggregate checkbox', () => {
+    render(<LineFilters {...defaultProps} />);
+    expect(screen.getByRole('checkbox', { name: 'Aggregate' })).toBeTruthy();
+  });
+
+  it('renders the Aggregate label', () => {
+    render(<LineFilters {...defaultProps} />);
+    expect(screen.getByText('Aggregate')).toBeTruthy();
+  });
+
+  it('renders Bus and Train mode toggle buttons', () => {
+    render(<LineFilters {...defaultProps} />);
+    // Radix ToggleGroup.Item renders as role="button" with aria-pressed
+    expect(screen.getByRole('button', { name: 'Bus' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Train' })).toBeTruthy();
+  });
+
+  it('reflects the unchecked state of the Aggregate checkbox', () => {
+    render(<LineFilters {...defaultProps} isAggregateVisible={false} />);
+    const checkbox = screen.getByRole('checkbox', { name: 'Aggregate' });
+    expect(checkbox.getAttribute('data-state')).toBe('unchecked');
+  });
+
+  it('reflects the checked state of the Aggregate checkbox', () => {
+    render(<LineFilters {...defaultProps} isAggregateVisible={true} />);
+    const checkbox = screen.getByRole('checkbox', { name: 'Aggregate' });
+    expect(checkbox.getAttribute('data-state')).toBe('checked');
+  });
+});
+
+describe('LineFilters interactions', () => {
+  it('calls setSearchText with the new value when the search input changes', () => {
+    const setSearchText = vi.fn();
+    render(<LineFilters {...defaultProps} setSearchText={setSearchText} />);
+    fireEvent.change(screen.getByPlaceholderText('Search lines'), {
+      target: { value: 'blue' },
+    });
+    expect(setSearchText).toHaveBeenCalledWith('blue');
+  });
+
+  it('calls selectAllVisibleLines when Select All is clicked', () => {
+    const selectAllVisibleLines = vi.fn();
+    render(
+      <LineFilters
+        {...defaultProps}
+        selectAllVisibleLines={selectAllVisibleLines}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Select All' }));
+    expect(selectAllVisibleLines).toHaveBeenCalledOnce();
+  });
+
+  it('calls clearSelections when Clear All is clicked', () => {
+    const clearSelections = vi.fn();
+    render(<LineFilters {...defaultProps} clearSelections={clearSelections} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Clear All' }));
+    expect(clearSelections).toHaveBeenCalledOnce();
+  });
+
+  it('calls toggleIsAggregateVisible when the Aggregate checkbox is clicked', () => {
+    const toggleIsAggregateVisible = vi.fn();
+    render(
+      <LineFilters
+        {...defaultProps}
+        toggleIsAggregateVisible={toggleIsAggregateVisible}
+      />,
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Aggregate' }));
+    expect(toggleIsAggregateVisible).toHaveBeenCalledOnce();
+  });
+
+  it('does not call clearSelections when Select All is clicked', () => {
+    const clearSelections = vi.fn();
+    render(<LineFilters {...defaultProps} clearSelections={clearSelections} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Select All' }));
+    expect(clearSelections).not.toHaveBeenCalled();
+  });
+
+  it('does not call selectAllVisibleLines when Clear All is clicked', () => {
+    const selectAllVisibleLines = vi.fn();
+    render(
+      <LineFilters
+        {...defaultProps}
+        selectAllVisibleLines={selectAllVisibleLines}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Clear All' }));
+    expect(selectAllVisibleLines).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/LineTableRow.test.tsx
+++ b/src/components/LineTableRow.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import LineTableRow from './LineTableRow';
+import type { Line } from '../@types/lines.types';
+import type { RidershipRecord } from '../@types/metrics.types';
+
+vi.mock('react-chartjs-2', () => ({
+  Line: () => <canvas data-testid="sparkline" />,
+}));
+
+const mockLine: Line = {
+  id: 801,
+  name: 'A Line',
+  former: 'Blue Line',
+  mode: 'Rail',
+  provider: 'DO',
+  selected: false,
+  visible: true,
+  averageRidership: 5000,
+  changeInRidership: 1000,
+  startingRidership: 4000,
+  endingRidership: 5500, // distinct from averageRidership to avoid duplicate text matches
+};
+
+const mockMetrics: RidershipRecord[] = [
+  {
+    year: 2022,
+    month: 1,
+    line_name: 801,
+    est_wkday_ridership: 5000,
+    est_sat_ridership: 3000,
+    est_sun_ridership: 2000,
+  },
+];
+
+const baseProps = {
+  onToggleSelectLine: vi.fn(),
+  line: mockLine,
+  id: 1,
+  dayOfWeek: 'est_wkday_ridership',
+  lineMetrics: mockMetrics,
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('LineTableRow rendering', () => {
+  it('renders the line name', () => {
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} />
+        </tbody>
+      </table>,
+    );
+    expect(screen.getByText('A Line')).toBeTruthy();
+  });
+
+  it('renders the row rank', () => {
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} id={3} />
+        </tbody>
+      </table>,
+    );
+    expect(screen.getByText('3')).toBeTruthy();
+  });
+
+  it('renders a checkbox', () => {
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} />
+        </tbody>
+      </table>,
+    );
+    expect(screen.getByRole('checkbox')).toBeTruthy();
+  });
+
+  it('renders nothing when lineMetrics is falsy', () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} lineMetrics={undefined as never} />
+        </tbody>
+      </table>,
+    );
+    expect(container.querySelector('tr')).toBeNull();
+  });
+
+  it('shows the former name text in the DOM (hidden via CSS)', () => {
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} />
+        </tbody>
+      </table>,
+    );
+    expect(screen.getByText('Former Blue Line')).toBeTruthy();
+  });
+});
+
+describe('LineTableRow expanded view', () => {
+  it('renders the sparkline chart when expanded', () => {
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} isExpanded />
+        </tbody>
+      </table>,
+    );
+    expect(screen.getByTestId('sparkline')).toBeTruthy();
+  });
+
+  it('shows formatted average ridership when expanded', () => {
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} isExpanded />
+        </tbody>
+      </table>,
+    );
+    expect(screen.getByText('5,000')).toBeTruthy();
+  });
+
+  it('shows positive change in ridership in green when expanded', () => {
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} isExpanded />
+        </tbody>
+      </table>,
+    );
+    const changeCell = screen.getByText('+1,000');
+    expect(changeCell.className).toContain('text-green-600');
+  });
+
+  it('shows negative change in ridership in red when expanded', () => {
+    const lineWithDecline = { ...mockLine, changeInRidership: -200, endingRidership: 4800 };
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} line={lineWithDecline} isExpanded />
+        </tbody>
+      </table>,
+    );
+    const changeCell = screen.getByText('-200');
+    expect(changeCell.className).toContain('text-red-600');
+  });
+
+  it('does not render sparkline when not expanded', () => {
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} isExpanded={false} />
+        </tbody>
+      </table>,
+    );
+    expect(screen.queryByTestId('sparkline')).toBeNull();
+  });
+});
+
+describe('LineTableRow interactions', () => {
+  it('calls onToggleSelectLine with the line when checkbox is clicked', () => {
+    const onToggleSelectLine = vi.fn();
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} onToggleSelectLine={onToggleSelectLine} />
+        </tbody>
+      </table>,
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onToggleSelectLine).toHaveBeenCalledWith(mockLine);
+  });
+
+  it('reflects the selected state on the checkbox', () => {
+    const selectedLine = { ...mockLine, selected: true };
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} line={selectedLine} />
+        </tbody>
+      </table>,
+    );
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.getAttribute('data-state')).toBe('checked');
+  });
+
+  it('reflects the unselected state on the checkbox', () => {
+    render(
+      <table>
+        <tbody>
+          <LineTableRow {...baseProps} />
+        </tbody>
+      </table>,
+    );
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.getAttribute('data-state')).toBe('unchecked');
+  });
+});

--- a/src/components/OutputArea.test.tsx
+++ b/src/components/OutputArea.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import OutputArea from './OutputArea';
+import type { Line } from '../@types/lines.types';
+
+vi.mock('react-chartjs-2', () => ({
+  Line: () => <canvas data-testid="line-chart" />,
+}));
+
+const makeLine = (overrides: Partial<Line>): Line => ({
+  id: 801,
+  name: 'A Line',
+  mode: 'Rail',
+  provider: 'DO',
+  selected: false,
+  visible: true,
+  ...overrides,
+});
+
+const emptyProps = {
+  chartDatasets: [],
+  months: [],
+  lines: [],
+};
+
+const datasetFixture = {
+  data: [{ time: '2022 1', stat: 5000 }] as { time: string; stat: number }[],
+  label: 'A Line',
+  backgroundColor: '#0072bc',
+  borderColor: '#0072bc',
+};
+
+describe('OutputArea with no datasets', () => {
+  it('shows the "Please select a Metro line." placeholder', () => {
+    render(<OutputArea {...emptyProps} />);
+    expect(screen.getByText('Please select a Metro line.')).toBeTruthy();
+  });
+
+  it('does not render the chart when there are no datasets', () => {
+    render(<OutputArea {...emptyProps} />);
+    expect(screen.queryByTestId('line-chart')).toBeNull();
+  });
+});
+
+describe('OutputArea with datasets', () => {
+  it('renders the chart when at least one dataset is provided', () => {
+    render(
+      <OutputArea
+        chartDatasets={[datasetFixture]}
+        months={['2022 1']}
+        lines={[]}
+      />,
+    );
+    expect(screen.getByTestId('line-chart')).toBeTruthy();
+  });
+
+  it('does not show the placeholder when datasets are provided', () => {
+    render(
+      <OutputArea
+        chartDatasets={[datasetFixture]}
+        months={['2022 1']}
+        lines={[]}
+      />,
+    );
+    expect(screen.queryByText('Please select a Metro line.')).toBeNull();
+  });
+
+  it('renders SummaryData for the passed lines', () => {
+    const selectedLine = makeLine({
+      selected: true,
+      averageRidership: 4000,
+      changeInRidership: 200,
+      endingRidership: 4200,
+    });
+    render(
+      <OutputArea
+        chartDatasets={[datasetFixture]}
+        months={['2022 1']}
+        lines={[selectedLine]}
+      />,
+    );
+    expect(screen.getByText('Average Ridership')).toBeTruthy();
+  });
+
+  it('does not render SummaryData stats when no lines are selected', () => {
+    render(
+      <OutputArea
+        chartDatasets={[datasetFixture]}
+        months={['2022 1']}
+        lines={[makeLine({ selected: false })]}
+      />,
+    );
+    expect(screen.queryByText('Average Ridership')).toBeNull();
+  });
+});

--- a/src/components/SummaryData.test.tsx
+++ b/src/components/SummaryData.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SummaryData from './SummaryData';
+import type { Line } from '../@types/lines.types';
+
+const makeLine = (overrides: Partial<Line>): Line => ({
+  id: 801,
+  name: 'A Line',
+  mode: 'Rail',
+  provider: 'DO',
+  selected: false,
+  visible: true,
+  ...overrides,
+});
+
+describe('SummaryData with no selected lines', () => {
+  it('renders nothing when the lines array is empty', () => {
+    render(<SummaryData lines={[]} />);
+    expect(screen.queryByText('Average Ridership')).toBeNull();
+  });
+
+  it('renders nothing when all lines are unselected', () => {
+    render(
+      <SummaryData
+        lines={[
+          makeLine({ selected: false }),
+          makeLine({ id: 802, name: 'B Line', selected: false }),
+        ]}
+      />,
+    );
+    expect(screen.queryByText('Average Ridership')).toBeNull();
+  });
+});
+
+describe('SummaryData with selected lines', () => {
+  it('shows the Average Ridership label', () => {
+    render(<SummaryData lines={[makeLine({ selected: true, averageRidership: 5000 })]} />);
+    expect(screen.getByText('Average Ridership')).toBeTruthy();
+  });
+
+  it('shows the Ending Ridership label', () => {
+    render(
+      <SummaryData
+        lines={[makeLine({ selected: true, endingRidership: 4000, changeInRidership: 0 })]}
+      />,
+    );
+    expect(screen.getByText('Ending Ridership')).toBeTruthy();
+  });
+
+  it('sums average ridership across selected lines', () => {
+    const lines = [
+      makeLine({ selected: true, averageRidership: 10000 }),
+      makeLine({ id: 802, name: 'B Line', selected: true, averageRidership: 5000 }),
+    ];
+    render(<SummaryData lines={lines} />);
+    expect(screen.getByText('15,000')).toBeTruthy();
+  });
+
+  it('sums ending ridership across selected lines', () => {
+    const lines = [
+      makeLine({ selected: true, endingRidership: 8000, changeInRidership: 500 }),
+      makeLine({ id: 802, name: 'B Line', selected: true, endingRidership: 2000, changeInRidership: 100 }),
+    ];
+    render(<SummaryData lines={lines} />);
+    expect(screen.getByText('10,000')).toBeTruthy();
+  });
+
+  it('shows a positive change with a leading + sign', () => {
+    render(
+      <SummaryData
+        lines={[makeLine({ selected: true, changeInRidership: 2000, endingRidership: 9000 })]}
+      />,
+    );
+    expect(screen.getByLabelText('Change').textContent).toBe('+2,000');
+  });
+
+  it('shows a negative change without a + sign', () => {
+    render(
+      <SummaryData
+        lines={[makeLine({ selected: true, changeInRidership: -500, endingRidership: 8000 })]}
+      />,
+    );
+    expect(screen.getByLabelText('Change').textContent).toBe('-500');
+  });
+
+  it('applies red styling when change is negative', () => {
+    render(
+      <SummaryData
+        lines={[makeLine({ selected: true, changeInRidership: -100, endingRidership: 5000 })]}
+      />,
+    );
+    const changeEl = screen.getByLabelText('Change');
+    expect(changeEl.className).toContain('text-red-600');
+  });
+
+  it('applies green styling when change is positive', () => {
+    render(
+      <SummaryData
+        lines={[makeLine({ selected: true, changeInRidership: 100, endingRidership: 5000 })]}
+      />,
+    );
+    const changeEl = screen.getByLabelText('Change');
+    expect(changeEl.className).toContain('text-green-600');
+  });
+
+  it('lists the names of all selected lines', () => {
+    const lines = [
+      makeLine({ selected: true, name: 'A Line' }),
+      makeLine({ id: 802, name: 'B Line', selected: true }),
+    ];
+    render(<SummaryData lines={lines} />);
+    expect(screen.getByText(/A Line/)).toBeTruthy();
+    expect(screen.getByText(/B Line/)).toBeTruthy();
+  });
+
+  it('excludes unselected lines from calculations', () => {
+    const lines = [
+      makeLine({ selected: true, averageRidership: 5000 }),
+      makeLine({ id: 802, name: 'B Line', selected: false, averageRidership: 9999 }),
+    ];
+    render(<SummaryData lines={lines} />);
+    expect(screen.getByText('5,000')).toBeTruthy();
+    expect(screen.queryByText('14,999')).toBeNull();
+  });
+
+  it('treats undefined averageRidership as 0 in the sum', () => {
+    const lines = [
+      makeLine({ selected: true, averageRidership: undefined }),
+      makeLine({ id: 802, name: 'B Line', selected: true, averageRidership: 3000 }),
+    ];
+    render(<SummaryData lines={lines} />);
+    expect(screen.getByText('3,000')).toBeTruthy();
+  });
+
+  it('shows the Selected label with selected line names', () => {
+    render(
+      <SummaryData
+        lines={[makeLine({ selected: true, name: 'A Line', averageRidership: 1000 })]}
+      />,
+    );
+    expect(screen.getByText(/Selected:/)).toBeTruthy();
+  });
+});

--- a/src/utils/calc.test.ts
+++ b/src/utils/calc.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { calcAvg, calcAbsChange, calcEnd, calcStart } from './calc';
+import type { RidershipRecord } from '../@types/metrics.types';
+
+const makeRecord = (
+  year: number,
+  month: number,
+  wkday: number | null,
+  sat: number | null = null,
+  sun: number | null = null,
+): RidershipRecord => ({
+  year,
+  month,
+  line_name: 801,
+  est_wkday_ridership: wkday,
+  est_sat_ridership: sat,
+  est_sun_ridership: sun,
+});
+
+// Unsorted: March, January, June
+const records = [
+  makeRecord(2022, 3, 1000, 500, 300),
+  makeRecord(2022, 1, 2000, 800, 400),
+  makeRecord(2022, 6, 3000, 1200, 600),
+];
+
+describe('calcAvg', () => {
+  it('returns the average weekday ridership', () => {
+    expect(calcAvg(records, 'est_wkday_ridership')).toBe(2000);
+  });
+
+  it('returns the average saturday ridership', () => {
+    expect(calcAvg(records, 'est_sat_ridership')).toBeCloseTo(833.33, 1);
+  });
+
+  it('returns the average sunday ridership', () => {
+    expect(calcAvg(records, 'est_sun_ridership')).toBeCloseTo(433.33, 1);
+  });
+
+  it('treats null values as 0', () => {
+    const mixed = [makeRecord(2022, 1, null), makeRecord(2022, 2, 3000)];
+    expect(calcAvg(mixed, 'est_wkday_ridership')).toBe(1500);
+  });
+
+  it('handles a single record', () => {
+    expect(calcAvg([makeRecord(2022, 1, 500)], 'est_wkday_ridership')).toBe(500);
+  });
+
+  it('handles all-null values as average of 0s', () => {
+    const nulls = [makeRecord(2022, 1, null), makeRecord(2022, 2, null)];
+    expect(calcAvg(nulls, 'est_wkday_ridership')).toBe(0);
+  });
+});
+
+describe('calcAbsChange', () => {
+  it('returns last minus first ridership after sorting by date', () => {
+    // Sorted: Jan=2000, Mar=1000, Jun=3000 → last - first = 3000 - 2000 = 1000
+    expect(calcAbsChange([...records], 'est_wkday_ridership')).toBe(1000);
+  });
+
+  it('returns negative value when ridership declined', () => {
+    const declining = [makeRecord(2022, 1, 5000), makeRecord(2022, 6, 2000)];
+    expect(calcAbsChange(declining, 'est_wkday_ridership')).toBe(-3000);
+  });
+
+  it('returns 0 for a single record', () => {
+    expect(calcAbsChange([makeRecord(2022, 1, 1000)], 'est_wkday_ridership')).toBe(0);
+  });
+
+  it('sorts by year then month across multiple years', () => {
+    const multiYear = [makeRecord(2023, 1, 8000), makeRecord(2021, 6, 4000)];
+    expect(calcAbsChange(multiYear, 'est_wkday_ridership')).toBe(4000);
+  });
+
+  it('treats null as 0 for both endpoints', () => {
+    const withNull = [makeRecord(2022, 1, null), makeRecord(2022, 6, 3000)];
+    expect(calcAbsChange(withNull, 'est_wkday_ridership')).toBe(3000);
+  });
+
+  it('works for saturday ridership', () => {
+    // Sorted: Jan=800, Mar=500, Jun=1200 → 1200 - 800 = 400
+    expect(calcAbsChange([...records], 'est_sat_ridership')).toBe(400);
+  });
+});
+
+describe('calcEnd', () => {
+  it('returns the most recent weekday ridership', () => {
+    // Sorted chronologically, last is June=3000
+    expect(calcEnd([...records], 'est_wkday_ridership')).toBe(3000);
+  });
+
+  it('returns the most recent saturday ridership', () => {
+    expect(calcEnd([...records], 'est_sat_ridership')).toBe(1200);
+  });
+
+  it('handles a single record', () => {
+    expect(calcEnd([makeRecord(2022, 1, 999)], 'est_wkday_ridership')).toBe(999);
+  });
+
+  it('treats a null last value as 0', () => {
+    const withNull = [makeRecord(2022, 1, 500), makeRecord(2022, 6, null)];
+    expect(calcEnd(withNull, 'est_wkday_ridership')).toBe(0);
+  });
+
+  it('picks the later year as the end', () => {
+    const multiYear = [makeRecord(2023, 1, 9000), makeRecord(2021, 12, 1000)];
+    expect(calcEnd(multiYear, 'est_wkday_ridership')).toBe(9000);
+  });
+});
+
+describe('calcStart', () => {
+  it('returns the earliest weekday ridership', () => {
+    // Sorted chronologically, first is January=2000
+    expect(calcStart([...records], 'est_wkday_ridership')).toBe(2000);
+  });
+
+  it('returns the earliest saturday ridership', () => {
+    expect(calcStart([...records], 'est_sat_ridership')).toBe(800);
+  });
+
+  it('handles a single record', () => {
+    expect(calcStart([makeRecord(2022, 1, 750)], 'est_wkday_ridership')).toBe(750);
+  });
+
+  it('treats a null first value as 0', () => {
+    const withNull = [makeRecord(2022, 1, null), makeRecord(2022, 6, 500)];
+    expect(calcStart(withNull, 'est_wkday_ridership')).toBe(0);
+  });
+
+  it('picks the earlier year as the start', () => {
+    const multiYear = [makeRecord(2023, 1, 9000), makeRecord(2021, 12, 1000)];
+    expect(calcStart(multiYear, 'est_wkday_ridership')).toBe(1000);
+  });
+});

--- a/src/utils/lines.test.ts
+++ b/src/utils/lines.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getLineColor,
+  getLineNames,
+  lineNameSortFunction,
+  generateCSV,
+} from './lines';
+import type { Line } from '../@types/lines.types';
+import type { ConsolidatedRidership } from '../@types/metrics.types';
+
+const makeLine = (overrides: Partial<Line>): Line => ({
+  id: 1,
+  name: 'Line 1',
+  mode: 'Bus',
+  provider: 'DO',
+  selected: false,
+  visible: true,
+  ...overrides,
+});
+
+describe('getLineColor', () => {
+  it('returns the defined color for the A Line (801)', () => {
+    expect(getLineColor(801)).toBe('#0072bc');
+  });
+
+  it('returns the defined color for the B Line (802)', () => {
+    expect(getLineColor(802)).toBe('#eb131b');
+  });
+
+  it('returns the defined color for the C Line (803)', () => {
+    expect(getLineColor(803)).toBe('#58a738');
+  });
+
+  it('returns the defined color for the K Line (807)', () => {
+    expect(getLineColor(807)).toBe('#e56db1');
+  });
+
+  it('returns undefined for a number not in any known list', () => {
+    expect(getLineColor(99999)).toBeUndefined();
+  });
+});
+
+describe('getLineNames', () => {
+  it('returns a lettered current name for the A Line (801)', () => {
+    expect(getLineNames(801).current).toBe('A Line');
+  });
+
+  it('returns a former name for lines that have one', () => {
+    expect(getLineNames(801).former).toBe('Blue Line');
+    expect(getLineNames(802).former).toBe('Red Line');
+    expect(getLineNames(804).former).toBe('Expo Line');
+  });
+
+  it('does not include a former name for lines without one (807 K Line)', () => {
+    expect(getLineNames(807).former).toBeUndefined();
+  });
+
+  it('returns "Line N" for unknown line numbers', () => {
+    expect(getLineNames(99999).current).toBe('Line 99999');
+  });
+
+  it('does not include a former name for unknown lines', () => {
+    expect(getLineNames(99999).former).toBeUndefined();
+  });
+
+  it('returns correct letter for each defined line', () => {
+    expect(getLineNames(802).current).toBe('B Line');
+    expect(getLineNames(803).current).toBe('C Line');
+    expect(getLineNames(805).current).toBe('D Line');
+    expect(getLineNames(804).current).toBe('E Line');
+    expect(getLineNames(806).current).toBe('L Line');
+    expect(getLineNames(807).current).toBe('K Line');
+    expect(getLineNames(901).current).toBe('G Line');
+    expect(getLineNames(910).current).toBe('J Line');
+  });
+});
+
+describe('lineNameSortFunction', () => {
+  it('places lettered lines before numbered lines', () => {
+    const lettered = makeLine({ name: 'A Line' });
+    const numbered = makeLine({ name: 'Line 2' });
+    expect(lineNameSortFunction(lettered, numbered)).toBeLessThan(0);
+  });
+
+  it('places numbered lines after lettered lines', () => {
+    const numbered = makeLine({ name: 'Line 2' });
+    const lettered = makeLine({ name: 'A Line' });
+    expect(lineNameSortFunction(numbered, lettered)).toBeGreaterThan(0);
+  });
+
+  it('sorts numbered lines numerically (not lexicographically)', () => {
+    const line2 = makeLine({ id: 2, name: 'Line 2' });
+    const line10 = makeLine({ id: 10, name: 'Line 10' });
+    expect(lineNameSortFunction(line2, line10)).toBeLessThan(0);
+  });
+
+  it('sorts lettered lines alphabetically', () => {
+    const a = makeLine({ name: 'A Line' });
+    const b = makeLine({ name: 'B Line' });
+    expect(lineNameSortFunction(a, b)).toBeLessThan(0);
+    expect(lineNameSortFunction(b, a)).toBeGreaterThan(0);
+  });
+
+  it('returns 0 for equal names', () => {
+    const a = makeLine({ name: 'A Line' });
+    const b = makeLine({ name: 'A Line' });
+    expect(lineNameSortFunction(a, b)).toBe(0);
+  });
+
+  it('two numbered lines maintain correct numerical order', () => {
+    const line5 = makeLine({ id: 5, name: 'Line 5' });
+    const line20 = makeLine({ id: 20, name: 'Line 20' });
+    expect(lineNameSortFunction(line5, line20)).toBeLessThan(0);
+  });
+});
+
+describe('generateCSV', () => {
+  it('returns a data URI string', () => {
+    const csv = generateCSV({});
+    expect(csv.startsWith('data:text/csv;charset=utf-8,')).toBe(true);
+  });
+
+  it('includes CSV column headers', () => {
+    const csv = decodeURI(generateCSV({}));
+    expect(csv).toContain(
+      'line_name,year,month,est_wkday_ridership,est_sat_ridership,est_sun_ridership',
+    );
+  });
+
+  it('includes rows for selected lines', () => {
+    const ridership: ConsolidatedRidership = {
+      '801': {
+        selected: true,
+        ridershipRecords: [
+          {
+            year: 2022,
+            month: 1,
+            line_name: 801,
+            est_wkday_ridership: 5000,
+            est_sat_ridership: 3000,
+            est_sun_ridership: 2000,
+          },
+        ],
+      },
+    };
+    const csv = decodeURI(generateCSV(ridership));
+    expect(csv).toContain('A Line');
+    expect(csv).toContain('2022');
+    expect(csv).toContain('5000');
+  });
+
+  it('excludes rows for unselected lines', () => {
+    const ridership: ConsolidatedRidership = {
+      '801': {
+        selected: false,
+        ridershipRecords: [
+          {
+            year: 2022,
+            month: 1,
+            line_name: 801,
+            est_wkday_ridership: 5000,
+            est_sat_ridership: 3000,
+            est_sun_ridership: 2000,
+          },
+        ],
+      },
+    };
+    const csv = decodeURI(generateCSV(ridership));
+    expect(csv).not.toContain('5000');
+  });
+
+  it('uses the friendly line name in the CSV row', () => {
+    const ridership: ConsolidatedRidership = {
+      '802': {
+        selected: true,
+        ridershipRecords: [
+          {
+            year: 2023,
+            month: 6,
+            line_name: 802,
+            est_wkday_ridership: 12000,
+            est_sat_ridership: 8000,
+            est_sun_ridership: 6000,
+          },
+        ],
+      },
+    };
+    const csv = decodeURI(generateCSV(ridership));
+    expect(csv).toContain('B Line');
+    expect(csv).not.toContain('802');
+  });
+
+  it('includes multiple records for the same line', () => {
+    const ridership: ConsolidatedRidership = {
+      '801': {
+        selected: true,
+        ridershipRecords: [
+          {
+            year: 2022,
+            month: 1,
+            line_name: 801,
+            est_wkday_ridership: 1000,
+            est_sat_ridership: null,
+            est_sun_ridership: null,
+          },
+          {
+            year: 2022,
+            month: 2,
+            line_name: 801,
+            est_wkday_ridership: 2000,
+            est_sat_ridership: null,
+            est_sun_ridership: null,
+          },
+        ],
+      },
+    };
+    const csv = decodeURI(generateCSV(ridership));
+    expect(csv).toContain('1000');
+    expect(csv).toContain('2000');
+  });
+
+  it('returns only headers for an empty ridership object', () => {
+    const csv = decodeURI(generateCSV({}));
+    const lines = csv.split('\r\n').filter(Boolean);
+    expect(lines).toHaveLength(1); // just the header line
+  });
+});


### PR DESCRIPTION
## Summary

- Added 7 new test files covering every previously untested utility function and UI component
- 170 tests pass across 10 test files (up from 2 files / ~60 tests)
- Mocked `react-chartjs-2` in component tests that render charts to avoid canvas dependencies in jsdom

## Files added

| File | Tests | Covers |
|---|---|---|
| `src/utils/calc.test.ts` | 21 | `calcAvg`, `calcAbsChange`, `calcEnd`, `calcStart` — including null ridership values, single-record edge cases, and multi-year chronological sorting |
| `src/utils/lines.test.ts` | 22 | `getLineColor`, `getLineNames` (all 9 defined lines + unknowns), `lineNameSortFunction` (lettered before numbered, numerical not lexicographic ordering), `generateCSV` (data URI format, selected/unselected filtering, friendly name substitution) |
| `src/components/DateRangeSelector.test.tsx` | 14 | Renders four dropdowns with correct initial values; calls `setStartDate`, `setEndDate`, and `setDayOfWeek` on user interaction |
| `src/components/LineFilters.test.tsx` | 15 | Search input, Bus/Train mode toggles (Radix `ToggleGroup`), Select All / Clear All, Aggregate checkbox state and toggle callback |
| `src/components/SummaryData.test.tsx` | 13 | Empty state with no selection, ridership sums across multiple selected lines, ±change sign and color, excludes unselected lines, treats undefined metrics as 0 |
| `src/components/LineTableRow.test.tsx` | 13 | Row name/rank/checkbox rendering, expanded stats columns, sparkline chart, positive/negative change color, renders nothing when `lineMetrics` is falsy |
| `src/components/OutputArea.test.tsx` | 6 | Placeholder shown when no datasets, chart renders when datasets provided, delegates summary stats to `SummaryData` |

## Notes

- `ToggleGroup.Item` (Radix UI) renders as `role="button"` with `aria-pressed`, not `role="radio"` — tests query accordingly
- `HTMLElement` array elements from `getAllByRole` must be cast to `HTMLSelectElement` individually (e.g. `selects[0] as HTMLSelectElement`) to access `.value`; casting the whole array (`as HTMLSelectElement[]`) triggers `@typescript-eslint/no-unnecessary-type-assertion`