### PR TITLE
feat(dock): dockview contract — DockShell, contexts, layout storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "metro_ridership_app",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metro_ridership_app",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@fontsource-variable/overpass-mono": "^5.2.5",
         "@radix-ui/react-checkbox": "^1.1.1",
         "@radix-ui/react-radio-group": "^1.3.6",
         "@radix-ui/react-toggle-group": "^1.1.9",
         "chart.js": "^4.4.3",
+        "dockview-react": "^7.0.2",
         "lodash": "^4.17.21",
         "maplibre-gl": "^5.24.0",
         "react": "^19.1.0",
@@ -3273,6 +3274,34 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dockview": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/dockview/-/dockview-7.0.2.tgz",
+      "integrity": "sha512-QhgbJ7RTFsWvrs1lQZKPGCLTGjKU7kI5ZWX5lwU03arM9lIoQlbfv1b/uQ7V5zTkRw7JDndEqjKMgEFw2I8Kow==",
+      "license": "MIT",
+      "dependencies": {
+        "dockview-core": "^7.0.2"
+      }
+    },
+    "node_modules/dockview-core": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/dockview-core/-/dockview-core-7.0.2.tgz",
+      "integrity": "sha512-i666ndkUdT4U+Bo2Yu3d6KwCJNqe21VJ0oschdgcXucZ5TquzBFX94zcUBEfg4IewTv2BuiPJ7r/2JTGLLv6ig==",
+      "license": "MIT"
+    },
+    "node_modules/dockview-react": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/dockview-react/-/dockview-react-7.0.2.tgz",
+      "integrity": "sha512-tnbRM1C/Ok1n/HXGMF0OWmc6Qlx5pbsSJucxX+3XcuNYkZgKiaNJX3BpdBlSxexjytTI/Xywh0ZNGF3/4Fa9LA==",
+      "license": "MIT",
+      "dependencies": {
+        "dockview": "^7.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-radio-group": "^1.3.6",
     "@radix-ui/react-toggle-group": "^1.1.9",
     "chart.js": "^4.4.3",
+    "dockview-react": "^7.0.2",
     "lodash": "^4.17.21",
     "maplibre-gl": "^5.24.0",
     "react": "^19.1.0",

--- a/src/context/DashboardContext.tsx
+++ b/src/context/DashboardContext.tsx
@@ -1,0 +1,56 @@
+import {
+  createContext,
+  use,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from 'react';
+import type { ChartDataset } from 'chart.js';
+import type { UserDashboardInputState } from '../hooks/useUserDashboardInput';
+import type { CustomChartData } from '../@types/chart.types';
+import type { Line } from '../@types/lines.types';
+import type { ConsolidatedRidership } from '../@types/metrics.types';
+
+/**
+ * FROZEN CONTRACT — see src/plans/dockable-panels.md. Wave-2 PRs import from
+ * this file; do not change exported names or shapes.
+ */
+
+/* eslint-disable react-refresh/only-export-components -- contract module:
+   exports the provider component alongside its hook */
+
+/**
+ * The dashboard data/state that App.tsx currently threads to its children as
+ * props, exposed via context so dock panels can consume it from anywhere in
+ * the tree.
+ */
+export interface DashboardContextValue {
+  userDashboardInputState: UserDashboardInputState;
+  lines: Line[];
+  visibleLines: Line[];
+  ridershipByLine: ConsolidatedRidership;
+  chartDatasets: ChartDataset<'line', CustomChartData[]>[];
+  monthList: string[];
+  isLineSelectorExpanded: boolean;
+  setIsLineSelectorExpanded: Dispatch<SetStateAction<boolean>>;
+}
+
+const DashboardContext = createContext<DashboardContextValue | null>(null);
+
+export function DashboardProvider({
+  value,
+  children,
+}: {
+  value: DashboardContextValue;
+  children: ReactNode;
+}) {
+  return <DashboardContext value={value}>{children}</DashboardContext>;
+}
+
+export function useDashboard(): DashboardContextValue {
+  const value = use(DashboardContext);
+  if (!value) {
+    throw new Error('useDashboard must be used within a DashboardProvider');
+  }
+  return value;
+}

--- a/src/dock/DockLayoutContext.tsx
+++ b/src/dock/DockLayoutContext.tsx
@@ -1,0 +1,48 @@
+import { createContext, use, type ReactNode } from 'react';
+import { PANEL_IDS, type PanelId } from './DockShell';
+
+/**
+ * FROZEN CONTRACT — see src/plans/dockable-panels.md. Wave-2 PRs import from
+ * this file; do not change exported names or shapes.
+ */
+
+/* eslint-disable react-refresh/only-export-components -- contract module:
+   exports the provider component alongside its hook */
+
+export interface DockLayoutContextValue {
+  /** Whether each panel is currently shown in the dock. */
+  visibility: Record<PanelId, boolean>;
+  togglePanel: (id: PanelId) => void;
+  resetLayout: () => void;
+}
+
+const allVisible = Object.fromEntries(
+  PANEL_IDS.map((id) => [id, true]),
+) as Record<PanelId, boolean>;
+
+/**
+ * Safe no-op default (all panels visible) so consumers — e.g. the header
+ * controls — render standalone before the dashboard provides the real
+ * implementation.
+ */
+const defaultValue: DockLayoutContextValue = {
+  visibility: allVisible,
+  togglePanel: () => {},
+  resetLayout: () => {},
+};
+
+const DockLayoutContext = createContext<DockLayoutContextValue>(defaultValue);
+
+export function DockLayoutProvider({
+  value,
+  children,
+}: {
+  value: DockLayoutContextValue;
+  children: ReactNode;
+}) {
+  return <DockLayoutContext value={value}>{children}</DockLayoutContext>;
+}
+
+export function useDockLayout(): DockLayoutContextValue {
+  return use(DockLayoutContext);
+}

--- a/src/dock/DockShell.test.tsx
+++ b/src/dock/DockShell.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { DockviewApi } from 'dockview-react';
+import DockShell, { PANEL_IDS, type PanelId } from './DockShell';
+import { LAYOUT_STORAGE_KEY, saveLayout } from '../utils/layoutStorage';
+
+const makePanels = (): Record<PanelId, ReactNode> =>
+  Object.fromEntries(
+    PANEL_IDS.map((id) => [id, <div key={id} data-testid={`content-${id}`} />]),
+  ) as Record<PanelId, ReactNode>;
+
+const renderShell = async (): Promise<DockviewApi> => {
+  let api: DockviewApi | undefined;
+  render(
+    <DockShell
+      panels={makePanels()}
+      onApiReady={(readyApi) => {
+        api = readyApi;
+      }}
+    />,
+  );
+  await waitFor(() => expect(api).toBeDefined());
+  return api!;
+};
+
+const panelIds = (api: DockviewApi): string[] =>
+  api.panels.map((panel) => panel.id).sort();
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('DockShell', () => {
+  it('builds the default layout when no save exists', async () => {
+    const api = await renderShell();
+    expect(panelIds(api)).toEqual([...PANEL_IDS].sort());
+  });
+
+  it('renders the injected content of every panel', async () => {
+    await renderShell();
+    for (const id of PANEL_IDS) {
+      expect(screen.getByTestId(`content-${id}`)).toBeTruthy();
+    }
+  });
+
+  it('restores a valid saved layout instead of the default', async () => {
+    // Produce a save that differs from the default (summary removed) with
+    // dockview's own serializer, so the fixture matches the real format.
+    const api = await renderShell();
+    api.removePanel(api.getPanel('summary')!);
+    const saved = api.toJSON();
+    cleanup();
+    saveLayout(saved);
+
+    const restoredApi = await renderShell();
+    expect(panelIds(restoredApi)).toEqual(
+      ['date-range', 'line-selector', 'chart', 'map'].sort(),
+    );
+  });
+
+  it('saves layout changes to storage (debounced)', async () => {
+    const api = await renderShell();
+    api.removePanel(api.getPanel('summary')!);
+
+    await waitFor(
+      () => {
+        const raw = localStorage.getItem(LAYOUT_STORAGE_KEY);
+        expect(raw).not.toBeNull();
+        const stored = JSON.parse(raw!) as {
+          version: number;
+          layout: { panels: Record<string, unknown> };
+        };
+        expect(stored.version).toBe(1);
+        expect(Object.keys(stored.layout.panels).sort()).toEqual(
+          ['date-range', 'line-selector', 'chart', 'map'].sort(),
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('falls back to the default layout when the save is corrupt JSON', async () => {
+    localStorage.setItem(LAYOUT_STORAGE_KEY, '{not valid json');
+    const api = await renderShell();
+    expect(panelIds(api)).toEqual([...PANEL_IDS].sort());
+  });
+
+  it('rebuilds and wipes storage when a validated save fails deserialisation', async () => {
+    // Passes loadLayout's checks (version 1, known panel ids) but has a grid
+    // dockview itself cannot deserialise.
+    localStorage.setItem(
+      LAYOUT_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        layout: {
+          grid: {
+            root: { type: 'branch', data: 'not-a-node-list' },
+            width: 800,
+            height: 600,
+            orientation: 'HORIZONTAL',
+          },
+          panels: { chart: { id: 'chart', contentComponent: 'chart' } },
+        },
+      }),
+    );
+
+    const api = await renderShell();
+
+    expect(panelIds(api)).toEqual([...PANEL_IDS].sort());
+    const raw = localStorage.getItem(LAYOUT_STORAGE_KEY);
+    expect(raw ?? '').not.toContain('not-a-node-list');
+  });
+});

--- a/src/dock/DockShell.tsx
+++ b/src/dock/DockShell.tsx
@@ -1,0 +1,229 @@
+import {
+  createContext,
+  use,
+  useEffect,
+  useRef,
+  type FunctionComponent,
+  type ReactNode,
+} from 'react';
+import {
+  DockviewReact,
+  type DockviewApi,
+  type DockviewReadyEvent,
+  type DockviewTheme,
+  type IDockviewPanelProps,
+} from 'dockview-react';
+import { clearLayout, loadLayout, saveLayout } from '../utils/layoutStorage';
+import 'dockview-react/dist/styles/dockview.css';
+import './dockTheme.css';
+
+/**
+ * FROZEN CONTRACT — see src/plans/dockable-panels.md. Wave-2 PRs import from
+ * this file; do not change exported names or shapes.
+ */
+
+/* eslint-disable react-refresh/only-export-components -- contract module:
+   exports the DockShell component alongside its panel-id/theme constants */
+
+export const PANEL_IDS = [
+  'date-range',
+  'line-selector',
+  'chart',
+  'summary',
+  'map',
+] as const;
+
+export type PanelId = (typeof PANEL_IDS)[number];
+
+export interface PanelDef {
+  /** Key into the DockviewReact `components` map (same as the panel id). */
+  component: PanelId;
+  /** Tab title shown in the group header. */
+  title: string;
+  /**
+   * Placement in the default layout, relative to an earlier panel. Panels are
+   * added in PANEL_IDS order, so a reference must precede its dependants.
+   */
+  position?: {
+    referencePanel: PanelId;
+    direction: 'below' | 'right';
+  };
+  /** Default group height in px, applied after the default layout is built. */
+  defaultHeight?: number;
+  /** Default group width as a fraction of the dock width. */
+  defaultWidthRatio?: number;
+}
+
+/**
+ * Default layout mirrors the current dashboard: date-range as a full-width
+ * top strip, line-selector on the left (~25%), and a chart/summary/map stack
+ * to its right.
+ */
+export const PANEL_DEFS: Record<PanelId, PanelDef> = {
+  'date-range': {
+    component: 'date-range',
+    title: 'Date Range',
+    defaultHeight: 160,
+  },
+  'line-selector': {
+    component: 'line-selector',
+    title: 'Metro Lines',
+    position: { referencePanel: 'date-range', direction: 'below' },
+    defaultWidthRatio: 0.25,
+  },
+  chart: {
+    component: 'chart',
+    title: 'Ridership',
+    position: { referencePanel: 'line-selector', direction: 'right' },
+  },
+  summary: {
+    component: 'summary',
+    title: 'Summary',
+    position: { referencePanel: 'chart', direction: 'below' },
+  },
+  map: {
+    component: 'map',
+    title: 'Map',
+    position: { referencePanel: 'summary', direction: 'below' },
+  },
+};
+
+/** gap matches the dashboard's Tailwind `gap-4` between panes. */
+export const METRO_DOCK_THEME: DockviewTheme = {
+  name: 'metro',
+  className: 'dockview-theme-metro',
+  colorScheme: 'light',
+  gap: 16,
+};
+
+const SAVE_DEBOUNCE_MS = 250;
+
+/**
+ * Panel content is injected via context rather than closed-over props so the
+ * `components` map can stay a stable module-level object. Dockview renders
+ * panels through React portals inside the DockviewReact tree, so this context
+ * (and any provider above DockShell) reaches the panel content.
+ */
+const PanelContentContext = createContext<Partial<Record<PanelId, ReactNode>>>(
+  {},
+);
+
+const makePanelComponent = (
+  id: PanelId,
+): FunctionComponent<IDockviewPanelProps> => {
+  const PanelContent: FunctionComponent<IDockviewPanelProps> = () => {
+    const panels = use(PanelContentContext);
+    return <>{panels[id] ?? null}</>;
+  };
+  PanelContent.displayName = `DockPanel(${id})`;
+  return PanelContent;
+};
+
+const panelComponents: Record<
+  string,
+  FunctionComponent<IDockviewPanelProps>
+> = Object.fromEntries(PANEL_IDS.map((id) => [id, makePanelComponent(id)]));
+
+const buildDefaultLayout = (api: DockviewApi): void => {
+  for (const id of PANEL_IDS) {
+    const def = PANEL_DEFS[id];
+    api.addPanel({
+      id,
+      component: def.component,
+      title: def.title,
+      ...(def.position ? { position: def.position } : {}),
+    });
+  }
+
+  /*
+   * Sizes are applied after the whole grid exists: an initialHeight on the
+   * first panel is meaningless while it is the only group. Guarded so the
+   * calls no-op in unmeasured containers (jsdom).
+   */
+  for (const id of PANEL_IDS) {
+    const { defaultHeight, defaultWidthRatio } = PANEL_DEFS[id];
+    const panel = api.getPanel(id);
+    if (!panel) continue;
+
+    if (defaultHeight !== undefined && api.height > 0) {
+      panel.api.setSize({ height: defaultHeight });
+    }
+    if (defaultWidthRatio !== undefined && api.width > 0) {
+      panel.api.setSize({ width: Math.round(api.width * defaultWidthRatio) });
+    }
+  }
+};
+
+export interface DockShellProps {
+  /**
+   * Content for each panel. Injected by the dashboard so wave-2 can supply
+   * real components without editing this file.
+   */
+  panels: Record<PanelId, ReactNode>;
+  /** Called once dockview is initialised (after restore or default build). */
+  onApiReady?: (api: DockviewApi) => void;
+}
+
+function DockShell({ panels, onApiReady }: DockShellProps) {
+  const saveTimerRef = useRef<number | null>(null);
+  const layoutListenerRef = useRef<{ dispose(): void } | null>(null);
+
+  useEffect(() => {
+    return () => {
+      layoutListenerRef.current?.dispose();
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+      }
+    };
+  }, []);
+
+  const onReady = (event: DockviewReadyEvent): void => {
+    const { api } = event;
+
+    const saved = loadLayout(PANEL_IDS);
+    let restored = false;
+
+    if (saved) {
+      try {
+        api.fromJSON(saved);
+        restored = true;
+      } catch {
+        // A payload can pass our validation yet still fail dockview's own
+        // deserialisation; drop it and rebuild from scratch.
+        api.clear();
+        clearLayout();
+      }
+    }
+
+    if (!restored) {
+      buildDefaultLayout(api);
+    }
+
+    layoutListenerRef.current = api.onDidLayoutChange(() => {
+      if (saveTimerRef.current !== null) {
+        window.clearTimeout(saveTimerRef.current);
+      }
+      saveTimerRef.current = window.setTimeout(() => {
+        saveTimerRef.current = null;
+        saveLayout(api.toJSON());
+      }, SAVE_DEBOUNCE_MS);
+    });
+
+    onApiReady?.(api);
+  };
+
+  return (
+    <PanelContentContext value={panels}>
+      <DockviewReact
+        components={panelComponents}
+        onReady={onReady}
+        theme={METRO_DOCK_THEME}
+        defaultRenderer="always"
+        dndStrategy="pointer"
+        disableFloatingGroups
+      />
+    </PanelContentContext>
+  );
+}
+
+export default DockShell;

--- a/src/dock/dockTheme.css
+++ b/src/dock/dockTheme.css
@@ -1,0 +1,44 @@
+/*
+ * Metro dockview theme: maps dockview's --dv-* variables to the app's
+ * `.pane` look (see src/index.css). Panel CONTENT padding (the `.pane p-8`
+ * feel) is applied by the dashboard's panel wrappers, not here.
+ */
+.dockview-theme-metro {
+  --dv-group-view-background-color: #f8f6f1;
+  --dv-tabs-and-actions-container-background-color: #f8f6f1;
+  --dv-border-radius: 0.5rem;
+  --dv-tab-border-radius: 0.5rem;
+  --dv-separator-border: transparent;
+  --dv-drag-over-background-color: rgba(120, 113, 108, 0.15);
+  --dv-drag-over-border-color: #9c9c90;
+  --dv-sash-color: transparent;
+  --dv-active-sash-color: rgba(120, 113, 108, 0.35);
+
+  /* Tabs: small bold uppercase, matching the app's legend/button styling.
+     Font family inherits Overpass Mono from the page body. */
+  --dv-tabs-and-actions-container-font-size: 0.75rem;
+  --dv-tabs-and-actions-container-height: 2.25rem;
+  --dv-tab-divider-color: transparent;
+  --dv-activegroup-visiblepanel-tab-background-color: #f8f6f1;
+  --dv-activegroup-visiblepanel-tab-color: #2f2f2f;
+  --dv-activegroup-hiddenpanel-tab-background-color: transparent;
+  --dv-activegroup-hiddenpanel-tab-color: #78716c;
+  --dv-inactivegroup-visiblepanel-tab-background-color: #f8f6f1;
+  --dv-inactivegroup-visiblepanel-tab-color: #57534e;
+  --dv-inactivegroup-hiddenpanel-tab-background-color: transparent;
+  --dv-inactivegroup-hiddenpanel-tab-color: #a8a29e;
+}
+
+/*
+ * The dock root paints --dv-group-view-background-color (dockview v7 has no
+ * --dv-background-color variable); keep the root transparent so the page
+ * background (#f3eee2) shows through the gaps between panes.
+ */
+.dv-dockview.dockview-theme-metro {
+  background-color: transparent;
+}
+
+.dockview-theme-metro .dv-tab {
+  font-weight: bold;
+  text-transform: uppercase;
+}

--- a/src/plans/dockable-panels.md
+++ b/src/plans/dockable-panels.md
@@ -1,0 +1,268 @@
+# Plan: Dockable Panels (VS Code-style panel management)
+
+## Context
+
+The dashboard's layout is currently a fixed Tailwind grid in `App.tsx`: a
+date-range strip on top, the line selector on the left (~25%), and
+chart/summary/map stacked on the right. The goal is VS Code-style panel
+management — resizable, toggleable, drag-to-rearrange panels — using
+[dockview-react](https://dockview.dev) v7 (MIT, zero-dep, React 19
+compatible).
+
+The work is split into waves:
+
+- **Wave 1 (this PR, `feature/panels-dock-contract`)** lands the contract:
+  `DockShell`, both contexts, layout storage, theme CSS, and this document.
+  Nothing imports `DockShell` yet, so there is **no visual change**.
+- **Wave 2** is three parallel PRs (B2/B3/B4, below) that build on wave 1
+  **without modifying any wave-1 file**.
+
+**Every file listed in this document under "Wave-1 deliverables" is FROZEN
+once merged.** Wave-2 PRs import from them; they do not edit them. This
+document is the single source of truth for the shared shapes — a wave-2 PR
+should be buildable from this document alone.
+
+## Wave-1 deliverables (frozen)
+
+| File                            | Purpose                                              |
+| ------------------------------- | ---------------------------------------------------- |
+| `src/dock/DockShell.tsx`        | Dockview host; panel ids/defs, theme object          |
+| `src/dock/DockLayoutContext.tsx`| Panel visibility/reset context (safe no-op default)  |
+| `src/dock/dockTheme.css`        | `.dockview-theme-metro` variable overrides           |
+| `src/context/DashboardContext.tsx` | Dashboard data/state context for panels           |
+| `src/utils/layoutStorage.ts`    | localStorage persistence of the serialized layout    |
+| `src/test/setup.ts`             | jsdom `ResizeObserver` stub (vitest `setupFiles`)    |
+
+Dependency added: `dockview-react@^7.0.2`.
+
+---
+
+## Contract
+
+### Panel ids (`src/dock/DockShell.tsx`)
+
+```ts
+export const PANEL_IDS = [
+  'date-range',
+  'line-selector',
+  'chart',
+  'summary',
+  'map',
+] as const;
+
+export type PanelId = (typeof PANEL_IDS)[number];
+```
+
+Panel id, dockview component key, and `DockShellProps.panels` key are the
+same string for every panel.
+
+### Panel definitions
+
+```ts
+export interface PanelDef {
+  component: PanelId; // key into the DockviewReact `components` map
+  title: string;      // tab title
+  position?: { referencePanel: PanelId; direction: 'below' | 'right' };
+  defaultHeight?: number;     // px, applied after the default layout is built
+  defaultWidthRatio?: number; // fraction of dock width, applied after build
+}
+
+export const PANEL_DEFS: Record<PanelId, PanelDef>;
+```
+
+The default layout mirrors today's dashboard and is built by adding panels in
+`PANEL_IDS` order:
+
+- `date-range` — first panel (root group), full-width top strip,
+  `defaultHeight: 160`
+- `line-selector` — `below` `date-range`, `defaultWidthRatio: 0.25`
+- `chart` — `right` of `line-selector`
+- `summary` — `below` `chart`
+- `map` — `below` `summary`
+
+Sizes are applied *after* all panels exist via `panel.api.setSize(...)`,
+guarded by `api.width > 0` / `api.height > 0` (no-op in unmeasured
+containers such as jsdom).
+
+### DockShell
+
+```ts
+export interface DockShellProps {
+  panels: Record<PanelId, ReactNode>;
+  onApiReady?: (api: DockviewApi) => void;
+}
+export default function DockShell(props: DockShellProps): JSX.Element;
+```
+
+- `panels` injects the real content per panel id. Internally each dockview
+  component is a thin FC that reads the node from a context provided by
+  DockShell — dockview renders panel components through React portals inside
+  the `DockviewReact` tree, so **any context provider wrapping `DockShell`
+  (e.g. `DashboardProvider`) also reaches the panel content**.
+- `onApiReady(api)` fires once, after restore-or-default-build, with the
+  `DockviewApi`. Wave-2 wires maximize/visibility/reset through this api.
+- Dockview options set by DockShell (not overridable):
+  `defaultRenderer: 'always'` (hidden panels stay mounted — required so the
+  map's WebGL instance survives tab switches), `dndStrategy: 'pointer'`,
+  `disableFloatingGroups: true`.
+- Theme object (also exported):
+
+  ```ts
+  export const METRO_DOCK_THEME: DockviewTheme = {
+    name: 'metro',
+    className: 'dockview-theme-metro',
+    colorScheme: 'light',
+    gap: 16, // matches the old grid's Tailwind gap-4
+  };
+  ```
+
+- Persistence: on ready, `loadLayout(PANEL_IDS)`; if non-null, `api.fromJSON`
+  in try/catch — on throw, `api.clear()`, `clearLayout()`, and rebuild the
+  default layout. Saves via `api.onDidLayoutChange`, debounced 250 ms, as
+  `saveLayout(api.toJSON())`.
+
+### Layout storage (`src/utils/layoutStorage.ts`)
+
+- Key: `metro-panel-layout-v1` (exported as `LAYOUT_STORAGE_KEY`)
+- Payload: `{ version: 1, layout: SerializedDockview }`
+- API:
+
+  ```ts
+  loadLayout(allowedPanelIds: readonly string[]): SerializedDockview | null;
+  saveLayout(layout: SerializedDockview): void; // never throws
+  clearLayout(): void;                          // never throws
+  ```
+
+- `loadLayout` returns `null` unless: JSON parses, `version === 1`,
+  `layout.grid` and `layout.panels` are objects, there is at least one
+  panel, and every panel id in `layout.panels` is in `allowedPanelIds`.
+  Callers pass `PANEL_IDS` (the allowlist is a parameter to keep
+  `utils/` free of imports from `dock/`).
+
+Panel layout is deliberately **NOT** threaded through the URL query-param
+system. CLAUDE.md's "all UI state syncs to URL params" rule applies to
+shareable *dashboard* state (dates, lines, day-of-week…); panel layout is
+device-local UI chrome and lives only in localStorage.
+
+### DockLayoutContext (`src/dock/DockLayoutContext.tsx`)
+
+```ts
+export interface DockLayoutContextValue {
+  visibility: Record<PanelId, boolean>;
+  togglePanel: (id: PanelId) => void;
+  resetLayout: () => void;
+}
+export function DockLayoutProvider(props: {
+  value: DockLayoutContextValue;
+  children: ReactNode;
+}): JSX.Element;
+export function useDockLayout(): DockLayoutContextValue;
+```
+
+The context default is a **safe no-op**: all panels visible,
+`togglePanel`/`resetLayout` do nothing. This lets the header-controls PR
+(B4) merge and render standalone before the dashboard PR (B2) provides the
+real implementation.
+
+### DashboardContext (`src/context/DashboardContext.tsx`)
+
+```ts
+export interface DashboardContextValue {
+  userDashboardInputState: UserDashboardInputState; // from useUserDashboardInput
+  lines: Line[];
+  visibleLines: Line[];
+  ridershipByLine: ConsolidatedRidership;
+  chartDatasets: ChartDataset<'line', CustomChartData[]>[];
+  monthList: string[];
+  isLineSelectorExpanded: boolean;
+  setIsLineSelectorExpanded: Dispatch<SetStateAction<boolean>>;
+}
+export function DashboardProvider(props: {
+  value: DashboardContextValue;
+  children: ReactNode;
+}): JSX.Element;
+export function useDashboard(): DashboardContextValue; // throws if unprovided
+```
+
+These fields are exactly what `App.tsx` currently computes and threads as
+props to `DateRangeSelector`, `LineSelector`, and `OutputArea`.
+
+### Theme (`src/dock/dockTheme.css`)
+
+Scoped under `.dockview-theme-metro`; maps `--dv-*` variables to the app's
+`.pane` look (`src/index.css`): group background `#f8f6f1`, border radii
+`0.5rem`, transparent separators/sashes, drag-over
+`rgba(120,113,108,0.15)`, small bold uppercase tabs (font inherits Overpass
+Mono from the body). The dock root is forced transparent so the page
+background `#f3eee2` shows through the 16 px gaps between panes.
+
+Dockview v7 has **no** `--dv-background-color` variable — the root paints
+`--dv-group-view-background-color`, so the transparency is a scoped
+`.dv-dockview.dockview-theme-metro { background-color: transparent }` rule.
+
+Panel **content** padding (the `.pane p-8` feel) is applied by wave-2 panel
+wrappers, not by the theme.
+
+### Test setup
+
+`src/test/setup.ts` (wired via `test.setupFiles` in `vitest.config.ts`)
+stubs `ResizeObserver`, which dockview requires and jsdom lacks. Wave-2
+tests that render `DockShell` need nothing extra.
+
+---
+
+## Wave-2 split
+
+Each PR branches off main after wave 1 merges. None of them may modify a
+wave-1 file, `src/utils/queryParams.ts`, or `src/index.css`.
+
+### B2 — Dashboard integration (`src/App.tsx`)
+
+- Build `DashboardContextValue` in `App` from the existing hook/useMemo
+  output and wrap the tree in `DashboardProvider`.
+- Replace the Tailwind grid with `<DockShell panels={...} />` between
+  `Header` and `Footer`. Give the dock a sized container (it fills its
+  parent; e.g. a `grow` flex child with a min-height).
+- Panel content: thin wrapper components (new files under
+  `src/components/` or `src/dock/panels/`) that call `useDashboard()` and
+  render the existing `DateRangeSelector`, `LineSelector`, chart, summary,
+  and map components, adding `.pane`-style content padding (`p-8`).
+- Capture the `DockviewApi` from `onApiReady` and implement the real
+  `DockLayoutContextValue`:
+  - `togglePanel(id)`: if present, `api.removePanel(api.getPanel(id)!)`;
+    if absent, re-add via `PANEL_DEFS[id]` (component/title/position,
+    falling back to sensible placement if the reference panel is also
+    hidden). Track `visibility` from `api.onDidAddPanel` /
+    `api.onDidRemovePanel`.
+  - `resetLayout()`: `api.clear()`, `clearLayout()`, rebuild the default
+    layout (re-add panels in `PANEL_IDS` order per `PANEL_DEFS`).
+- Wrap everything in `DockLayoutProvider` so the header (B4) sees the real
+  implementation.
+
+### B3 — Map singleton (`src/components/Map.tsx` area)
+
+- The MapLibre instance must be created once and survive panel drag/resize;
+  `defaultRenderer: 'always'` keeps hidden panels mounted, so the map is
+  never unmounted by tab switching.
+- Handle container resizes (dockview panels resize freely): call
+  `map.resize()` on panel size changes (a `ResizeObserver` on the map
+  container is sufficient; no DockShell change needed).
+- Any singleton/ref hardening lives in new files or `src/components/`
+  (B3 may touch `src/components/`; it must not touch `src/dock/`).
+
+### B4 — Header panel controls (`src/components/Header.tsx`)
+
+- Add panel toggle buttons (one per `PANEL_IDS` entry, labels from
+  `PANEL_DEFS[id].title`) and a "reset layout" action to the header using
+  `useDockLayout()` — checked state from `visibility[id]`, clicks call
+  `togglePanel(id)` / `resetLayout()`.
+- Renders standalone before B2 lands thanks to the no-op context default:
+  buttons show all-visible and clicks do nothing until the dashboard
+  provides the real value.
+
+## Verification (wave 1)
+
+`npm run lint && npm run test && npm run build` — all green. DockShell
+tests cover: default layout build, restoring a valid save, corrupt-JSON
+fallback, wipe-and-rebuild when a validated save fails dockview
+deserialisation, debounced saving, and panel content injection.

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,13 @@
+/**
+ * jsdom does not implement ResizeObserver, which dockview requires; install a
+ * no-op stub before any test module loads dockview.
+ */
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = ResizeObserverStub;
+}

--- a/src/utils/layoutStorage.test.ts
+++ b/src/utils/layoutStorage.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { SerializedDockview } from 'dockview-react';
+import {
+  LAYOUT_STORAGE_KEY,
+  loadLayout,
+  saveLayout,
+  clearLayout,
+} from './layoutStorage';
+
+const ALLOWED_IDS = [
+  'date-range',
+  'line-selector',
+  'chart',
+  'summary',
+  'map',
+] as const;
+
+/**
+ * Minimal structurally-valid SerializedDockview; only the parts our
+ * validators inspect need to be realistic.
+ */
+const makeLayout = (panelIds: readonly string[]): SerializedDockview =>
+  ({
+    grid: {
+      root: { type: 'branch', data: [] },
+      width: 800,
+      height: 600,
+      orientation: 'HORIZONTAL',
+    },
+    panels: Object.fromEntries(
+      panelIds.map((id) => [id, { id, contentComponent: id, title: id }]),
+    ),
+  }) as unknown as SerializedDockview;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('saveLayout / loadLayout roundtrip', () => {
+  it('returns the saved layout unchanged', () => {
+    const layout = makeLayout(['chart', 'map']);
+    saveLayout(layout);
+    expect(loadLayout(ALLOWED_IDS)).toEqual(layout);
+  });
+
+  it('wraps the layout in a version-1 envelope', () => {
+    saveLayout(makeLayout(['chart']));
+    const raw = localStorage.getItem(LAYOUT_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect((JSON.parse(raw!) as { version: number }).version).toBe(1);
+  });
+});
+
+describe('loadLayout validation', () => {
+  it('returns null when nothing is stored', () => {
+    expect(loadLayout(ALLOWED_IDS)).toBeNull();
+  });
+
+  it('returns null for corrupt JSON', () => {
+    localStorage.setItem(LAYOUT_STORAGE_KEY, '{not valid json');
+    expect(loadLayout(ALLOWED_IDS)).toBeNull();
+  });
+
+  it('returns null for a non-object payload', () => {
+    localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify('a string'));
+    expect(loadLayout(ALLOWED_IDS)).toBeNull();
+  });
+
+  it('returns null for a wrong version', () => {
+    localStorage.setItem(
+      LAYOUT_STORAGE_KEY,
+      JSON.stringify({ version: 2, layout: makeLayout(['chart']) }),
+    );
+    expect(loadLayout(ALLOWED_IDS)).toBeNull();
+  });
+
+  it('returns null when a saved panel id is not in the allowlist', () => {
+    localStorage.setItem(
+      LAYOUT_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        layout: makeLayout(['chart', 'foreign-panel']),
+      }),
+    );
+    expect(loadLayout(ALLOWED_IDS)).toBeNull();
+  });
+
+  it('returns null for a layout with no panels', () => {
+    localStorage.setItem(
+      LAYOUT_STORAGE_KEY,
+      JSON.stringify({ version: 1, layout: makeLayout([]) }),
+    );
+    expect(loadLayout(ALLOWED_IDS)).toBeNull();
+  });
+
+  it('returns null when the layout is missing its grid', () => {
+    localStorage.setItem(
+      LAYOUT_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        layout: { panels: { chart: { id: 'chart' } } },
+      }),
+    );
+    expect(loadLayout(ALLOWED_IDS)).toBeNull();
+  });
+});
+
+describe('clearLayout', () => {
+  it('removes the stored layout', () => {
+    saveLayout(makeLayout(['chart']));
+    clearLayout();
+    expect(localStorage.getItem(LAYOUT_STORAGE_KEY)).toBeNull();
+    expect(loadLayout(ALLOWED_IDS)).toBeNull();
+  });
+});

--- a/src/utils/layoutStorage.ts
+++ b/src/utils/layoutStorage.ts
@@ -1,0 +1,65 @@
+import type { SerializedDockview } from 'dockview-react';
+
+/**
+ * localStorage persistence for the dockable panel layout.
+ *
+ * Layout is deliberately device-local: it is NOT threaded through the URL
+ * query params (that system is reserved for shareable dashboard state).
+ */
+export const LAYOUT_STORAGE_KEY = 'metro-panel-layout-v1';
+
+export interface StoredLayout {
+  version: 1;
+  layout: SerializedDockview;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+/**
+ * Load and validate a saved layout. Returns null unless the payload parses,
+ * has version 1, and every saved panel id is in the allowlist (a save from a
+ * newer app version with unknown panels must not be restored).
+ */
+export const loadLayout = (
+  allowedPanelIds: readonly string[],
+): SerializedDockview | null => {
+  try {
+    const raw = localStorage.getItem(LAYOUT_STORAGE_KEY);
+    if (!raw) return null;
+
+    const stored: unknown = JSON.parse(raw);
+    if (!isRecord(stored) || stored.version !== 1 || !isRecord(stored.layout)) {
+      return null;
+    }
+
+    const layout = stored.layout as unknown as SerializedDockview;
+    if (!isRecord(layout.grid) || !isRecord(layout.panels)) return null;
+
+    const panelIds = Object.keys(layout.panels);
+    if (panelIds.length === 0) return null;
+    if (!panelIds.every((id) => allowedPanelIds.includes(id))) return null;
+
+    return layout;
+  } catch {
+    return null;
+  }
+};
+
+export const saveLayout = (layout: SerializedDockview): void => {
+  try {
+    const stored: StoredLayout = { version: 1, layout };
+    localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(stored));
+  } catch {
+    // Persistence is best-effort; storage may be unavailable (private
+    // browsing) or full.
+  }
+};
+
+export const clearLayout = (): void => {
+  try {
+    localStorage.removeItem(LAYOUT_STORAGE_KEY);
+  } catch {
+    // Same best-effort contract as saveLayout.
+  }
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./src/test/setup.ts'],
   },
 });


### PR DESCRIPTION
## What

Wave-1 **contract PR** for VS Code-style panel management (resizable/toggleable/dockable panels). It lands the shared surface that three parallel wave-2 PRs — B2 dashboard integration (`App.tsx`), B3 map singleton, B4 header controls — build on **without modifying any file added here**. Nothing imports `DockShell` yet, so there is **no visual change**.

- **Dependency**: `dockview-react@^7.0.2` (MIT, zero-dep, React 19 compatible)
- **`src/dock/DockShell.tsx`**: hosts `DockviewReact`; exports `PANEL_IDS` (`date-range`, `line-selector`, `chart`, `summary`, `map`), `PANEL_DEFS`, `METRO_DOCK_THEME`. Panel content is injected via a `panels: Record<PanelId, ReactNode>` prop (threaded to dockview's portal-rendered panels through context, so providers above DockShell reach panel content). Default layout mirrors today's dashboard. Options: `defaultRenderer: 'always'` (map stays mounted), `dndStrategy: 'pointer'`, `disableFloatingGroups`. Restores a validated save via `api.fromJSON` with fallback to clear + rebuild + wipe; saves on `api.onDidLayoutChange` debounced 250 ms. `onApiReady(api)` exposes the `DockviewApi` for wave-2.
- **`src/dock/DockLayoutContext.tsx`**: `{ visibility, togglePanel, resetLayout }` with a safe all-visible no-op default so the header-controls PR renders standalone.
- **`src/context/DashboardContext.tsx`**: typed context matching exactly what `App.tsx` currently threads as props (`userDashboardInputState`, `lines`, `visibleLines`, `ridershipByLine`, `chartDatasets`, `monthList`, `isLineSelectorExpanded`/setter); `useDashboard()` throws if unprovided.
- **`src/utils/layoutStorage.ts`**: key `metro-panel-layout-v1`, payload `{ version: 1, layout: SerializedDockview }`, with version + panel-id-allowlist validation.
- **`src/dock/dockTheme.css`**: `.dockview-theme-metro` maps `--dv-*` vars to the app's `.pane` look; page background shows through 16 px gaps between panes.
- **Test setup**: `src/test/setup.ts` ResizeObserver stub wired via `test.setupFiles` (jsdom lacks it; dockview needs it).
- **`src/plans/dockable-panels.md`**: the frozen contract doc — panel ids, all exported shapes, storage schema, theming, and the wave-2 split, written so a fresh session can build any wave-2 PR from it alone. Panel layout is deliberately **not** in the URL-param system (that stays shareable dashboard state; layout is device-local).

## Flagged deviations from the brief

All dockview API names were verified against the installed v7.0.2 `.d.ts`; the brief's names all exist (`addPanel`/`addEdgeGroup`/`toJSON`/`fromJSON`/`onDidLayoutChange`/`maximizeGroup`, props `components`/`theme`/`defaultRenderer`/`dndStrategy`/`disableFloatingGroups`/`onReady`). Four small deviations:

1. **`--dv-background-color` does not exist in dockview v7** — the dock root paints `--dv-group-view-background-color`. The intended effect (page background through the gaps) is implemented as a scoped `.dv-dockview.dockview-theme-metro { background-color: transparent }` override instead.
2. **`loadLayout(allowedPanelIds)` takes the allowlist as a parameter** (callers pass `PANEL_IDS`) rather than importing it, to avoid a `utils/` → `dock/` import cycle. Documented in the contract.
3. **`METRO_DOCK_THEME` adds `gap: 16`** (dockview's theme-level group gap) so panes actually have the between-pane gaps the transparent-separator styling implies, matching the old grid's Tailwind `gap-4`.
4. **Default sizes are applied post-build via `panel.api.setSize`** (guarded by `api.width/height > 0`, so jsdom no-ops) instead of `initialHeight` at `addPanel` time — an `initialHeight` on the first panel is meaningless while it is the grid's only group.

## Verify

`npm run lint && npm run test && npm run build` — all green (matches CI):

```
lint:  eslint . — no errors, no warnings
test:  Test Files  16 passed (16) / Tests  284 passed (284)
build: tsc -b && vite build — ✓ built in 18.25s
```

(The vite chunk-size warning pre-exists this PR — the bundle already carries the ridership JSON, MapLibre, and Chart.js.)

New tests: `layoutStorage` (roundtrip, corrupt JSON, wrong version, foreign panel ids, empty/missing grid) and `DockShell` (default build, valid-save restore, corrupt-JSON fallback, wipe-and-rebuild when a validated save fails dockview deserialisation, debounced save, panel content injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)