### PR TITLE
feat(panels): maplibre singleton lifecycle (B3)

### DIFF
--- a/src/components/Map.css
+++ b/src/components/Map.css
@@ -4,6 +4,14 @@
   border-radius: inherit;
 }
 
+/* Singleton host div that owns the maplibre canvas; re-parented into
+   #lineMap on every mount, so it must always fill its container. */
+.map-host {
+  height: 100%;
+  width: 100%;
+  border-radius: inherit;
+}
+
 .maplibregl-popup table {
   border-collapse: collapse;
   margin-top: 6px;

--- a/src/components/Map.test.tsx
+++ b/src/components/Map.test.tsx
@@ -13,6 +13,7 @@ const captured = vi.hoisted(() => ({
   addControl: vi.fn(),
   mapRemove: vi.fn(),
   mapResize: vi.fn(),
+  mapTriggerRepaint: vi.fn(),
 }));
 
 vi.mock('maplibre-gl', () => ({
@@ -26,6 +27,7 @@ vi.mock('maplibre-gl', () => ({
         addControl: captured.addControl,
         remove: captured.mapRemove,
         resize: captured.mapResize,
+        triggerRepaint: captured.mapTriggerRepaint,
         setFeatureState: vi.fn(),
         getCanvas: vi
           .fn()
@@ -116,6 +118,14 @@ describe('Map', () => {
       first.unmount();
       render(<Map lines={[]} />);
       expect(captured.mapResize).toHaveBeenCalledTimes(2);
+    });
+
+    it('repaints after each attach (resize alone no-ops when the size is unchanged)', () => {
+      const first = render(<Map lines={[]} />);
+      expect(captured.mapTriggerRepaint).toHaveBeenCalledTimes(1);
+      first.unmount();
+      render(<Map lines={[]} />);
+      expect(captured.mapTriggerRepaint).toHaveBeenCalledTimes(2);
     });
 
     it('re-applies the selection filter on remount once the style is loaded', () => {

--- a/src/components/Map.test.tsx
+++ b/src/components/Map.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, act } from '@testing-library/react';
 import maplibregl from 'maplibre-gl';
-import Map from './Map';
+import Map, { __resetMapForTests } from './Map';
 import type { Line } from '../@types/lines.types';
 
 // Hoisted so the vi.mock factory below can close over them
@@ -12,6 +12,7 @@ const captured = vi.hoisted(() => ({
   addLayer: vi.fn(),
   addControl: vi.fn(),
   mapRemove: vi.fn(),
+  mapResize: vi.fn(),
 }));
 
 vi.mock('maplibre-gl', () => ({
@@ -24,6 +25,7 @@ vi.mock('maplibre-gl', () => ({
         setFilter: captured.setFilter,
         addControl: captured.addControl,
         remove: captured.mapRemove,
+        resize: captured.mapResize,
         setFeatureState: vi.fn(),
         getCanvas: vi
           .fn()
@@ -58,6 +60,8 @@ const makeLine = (overrides: Partial<Line> = {}): Line => ({
 });
 
 beforeEach(() => {
+  // Reset before clearing mocks — the reset helper calls the mocked remove()
+  __resetMapForTests();
   captured.loadCallback = undefined;
   vi.clearAllMocks();
 });
@@ -66,6 +70,11 @@ describe('Map', () => {
   it('renders the map container div', () => {
     const { container } = render(<Map lines={[]} />);
     expect(container.querySelector('#lineMap')).toBeTruthy();
+  });
+
+  it('attaches the singleton host div inside the container', () => {
+    const { container } = render(<Map lines={[]} />);
+    expect(container.querySelector('#lineMap > .map-host')).toBeTruthy();
   });
 
   it('initialises with the positron style when no MapTiler key is set', () => {
@@ -77,10 +86,67 @@ describe('Map', () => {
     );
   });
 
-  it('removes the map instance on unmount', () => {
-    const { unmount } = render(<Map lines={[]} />);
-    unmount();
-    expect(captured.mapRemove).toHaveBeenCalledOnce();
+  describe('singleton lifecycle', () => {
+    it('does not destroy the map instance on unmount', () => {
+      const { unmount } = render(<Map lines={[]} />);
+      unmount();
+      expect(captured.mapRemove).not.toHaveBeenCalled();
+    });
+
+    it('detaches the host div on unmount without destroying it', () => {
+      const { container, unmount } = render(<Map lines={[]} />);
+      unmount();
+      expect(container.querySelector('.map-host')).toBeNull();
+    });
+
+    it('reuses the same map instance across unmount and remount', () => {
+      const first = render(<Map lines={[]} />);
+      first.unmount();
+      const second = render(<Map lines={[]} />);
+
+      expect(vi.mocked(maplibregl.Map)).toHaveBeenCalledOnce();
+      expect(
+        second.container.querySelector('#lineMap > .map-host'),
+      ).toBeTruthy();
+    });
+
+    it('calls map.resize() after each attach', () => {
+      const first = render(<Map lines={[]} />);
+      expect(captured.mapResize).toHaveBeenCalledTimes(1);
+      first.unmount();
+      render(<Map lines={[]} />);
+      expect(captured.mapResize).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-applies the selection filter on remount once the style is loaded', () => {
+      const lines = [makeLine({ id: 801, selected: true })];
+      const first = render(<Map lines={lines} />);
+      act(() => {
+        captured.loadCallback?.();
+      });
+      first.unmount();
+      vi.clearAllMocks();
+
+      render(<Map lines={lines} />);
+
+      // No new load event — the filter comes from the remount sync effect
+      expect(captured.setFilter).toHaveBeenCalledWith('lines-selected', [
+        'in',
+        ['get', 'line_id'],
+        ['literal', [801]],
+      ]);
+    });
+
+    it('__resetMapForTests destroys the singleton so the next mount builds a fresh map', () => {
+      render(<Map lines={[]} />);
+      expect(vi.mocked(maplibregl.Map)).toHaveBeenCalledOnce();
+
+      __resetMapForTests();
+      expect(captured.mapRemove).toHaveBeenCalledOnce();
+
+      render(<Map lines={[]} />);
+      expect(vi.mocked(maplibregl.Map)).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('on map load', () => {

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -15,151 +15,196 @@ interface MapProps {
   lines: Line[];
 }
 
+/**
+ * Module-scope singleton: the MapLibre instance (and the div that owns its
+ * canvas) is created once and never destroyed. React mounts only attach and
+ * detach the host div, so camera position, layers, and the tile cache survive
+ * dockview panel hide/show, drag-docking, and layout switches.
+ */
+interface MapSingleton {
+  host: HTMLDivElement;
+  map: maplibregl.Map;
+  styleLoaded: boolean;
+  lines: Line[];
+}
+
+let singleton: MapSingleton | null = null;
+
+function applySelectionFilter(s: MapSingleton) {
+  const selectedIds = s.lines.filter((l) => l.selected).map((l) => l.id);
+  s.map.setFilter('lines-selected', [
+    'in',
+    ['get', 'line_id'],
+    ['literal', selectedIds],
+  ]);
+}
+
+function getOrCreateSingleton(): MapSingleton {
+  if (singleton != null) return singleton;
+
+  const host = document.createElement('div');
+  host.className = 'map-host';
+
+  const map = new maplibregl.Map({
+    attributionControl: { compact: true },
+    container: host,
+    style: STYLE_URL,
+    center: [-118.24, 34.05],
+    zoom: 10,
+    minZoom: 8,
+    maxZoom: 16,
+  });
+
+  map.addControl(new maplibregl.NavigationControl(), 'top-right');
+
+  const s: MapSingleton = { host, map, styleLoaded: false, lines: [] };
+
+  map.on('load', () => {
+    s.styleLoaded = true;
+
+    map.addSource('metro-lines', {
+      type: 'geojson',
+      data: '/metro_lines.geojson',
+      generateId: true,
+    });
+
+    // All lines dimmed — rendered below the selected layer
+    map.addLayer({
+      id: 'lines-all',
+      type: 'line',
+      source: 'metro-lines',
+      layout: { 'line-join': 'round', 'line-cap': 'round' },
+      paint: {
+        'line-color': '#999',
+        'line-opacity': 0.15,
+        'line-width': 2,
+      },
+    });
+
+    // Selected lines rendered on top with brand colors
+    map.addLayer({
+      id: 'lines-selected',
+      type: 'line',
+      source: 'metro-lines',
+      filter: ['in', ['get', 'line_id'], ['literal', []]],
+      layout: { 'line-join': 'round', 'line-cap': 'round' },
+      paint: {
+        'line-color': ['get', 'color'],
+        'line-opacity': 1,
+        'line-width': [
+          'case',
+          ['boolean', ['feature-state', 'hover'], false],
+          5,
+          3,
+        ],
+      },
+    });
+
+    // Hover popup
+    const popup = new Popup({
+      closeButton: false,
+      closeOnClick: false,
+    });
+
+    let hoveredId: string | number | undefined;
+
+    const onMouseMove = (
+      e: maplibregl.MapMouseEvent & {
+        features?: maplibregl.MapGeoJSONFeature[];
+      },
+    ) => {
+      if (!e.features?.length) return;
+
+      map.getCanvas().style.cursor = 'pointer';
+
+      if (hoveredId !== undefined) {
+        map.setFeatureState(
+          { source: 'metro-lines', id: hoveredId },
+          { hover: false },
+        );
+      }
+
+      hoveredId = e.features[0].id;
+      map.setFeatureState(
+        { source: 'metro-lines', id: hoveredId },
+        { hover: true },
+      );
+
+      const lineId = e.features[0].properties.line_id as number;
+      const lineData = s.lines.find((l) => l.id === lineId);
+      popup
+        .setLngLat(e.lngLat)
+        .setHTML(buildPopupHTML(e.features[0].properties.name as string, lineData))
+        .addTo(map);
+    };
+
+    const onMouseLeave = () => {
+      map.getCanvas().style.cursor = '';
+      popup.remove();
+
+      if (hoveredId !== undefined) {
+        map.setFeatureState(
+          { source: 'metro-lines', id: hoveredId },
+          { hover: false },
+        );
+      }
+      hoveredId = undefined;
+    };
+
+    map.on('mousemove', 'lines-selected', onMouseMove);
+    map.on('mouseleave', 'lines-selected', onMouseLeave);
+
+    // Apply initial selection state
+    applySelectionFilter(s);
+  });
+
+  singleton = s;
+  return s;
+}
+
+/**
+ * Test-only: destroy the singleton so each test starts from a clean slate.
+ * Production code must never call this — the whole point of the singleton is
+ * that the map instance outlives React mounts.
+ */
+// eslint-disable-next-line react-refresh/only-export-components -- test-only helper; HMR of this file must recreate the singleton anyway
+export function __resetMapForTests() {
+  if (singleton == null) return;
+  singleton.map.remove();
+  singleton = null;
+}
 
 export default function Map({ lines }: MapProps) {
   const mapContainer = useRef<HTMLDivElement>(null);
-  const map = useRef<maplibregl.Map | null>(null);
-  const isStyleLoaded = useRef(false);
-  const linesRef = useRef<Line[]>(lines);
 
-  // Initialize map once
+  // Attach the singleton's host div on mount, detach (but never destroy) on
+  // unmount. A ResizeObserver keeps the canvas sized to the container —
+  // MapLibre's own trackResize only watches the window, not dockview sashes.
   useEffect(() => {
-    if (map.current != null) return;
+    const container = mapContainer.current!;
+    const s = getOrCreateSingleton();
 
-    map.current = new maplibregl.Map({
-      attributionControl: { compact: true },
-      container: mapContainer.current!,
-      style: STYLE_URL,
-      center: [-118.24, 34.05],
-      zoom: 10,
-      minZoom: 8,
-      maxZoom: 16,
+    container.appendChild(s.host);
+    s.map.resize();
+
+    const observer = new ResizeObserver(() => {
+      s.map.resize();
     });
-
-    map.current.addControl(new maplibregl.NavigationControl(), 'top-right');
-
-    map.current.on('load', () => {
-      isStyleLoaded.current = true;
-
-      map.current!.addSource('metro-lines', {
-        type: 'geojson',
-        data: '/metro_lines.geojson',
-        generateId: true,
-      });
-
-      // All lines dimmed — rendered below the selected layer
-      map.current!.addLayer({
-        id: 'lines-all',
-        type: 'line',
-        source: 'metro-lines',
-        layout: { 'line-join': 'round', 'line-cap': 'round' },
-        paint: {
-          'line-color': '#999',
-          'line-opacity': 0.15,
-          'line-width': 2,
-        },
-      });
-
-      // Selected lines rendered on top with brand colors
-      map.current!.addLayer({
-        id: 'lines-selected',
-        type: 'line',
-        source: 'metro-lines',
-        filter: ['in', ['get', 'line_id'], ['literal', []]],
-        layout: { 'line-join': 'round', 'line-cap': 'round' },
-        paint: {
-          'line-color': ['get', 'color'],
-          'line-opacity': 1,
-          'line-width': [
-            'case',
-            ['boolean', ['feature-state', 'hover'], false],
-            5,
-            3,
-          ],
-        },
-      });
-
-      // Hover popup
-      const popup = new Popup({
-        closeButton: false,
-        closeOnClick: false,
-      });
-
-      let hoveredId: string | number | undefined;
-
-      const onMouseMove = (
-        e: maplibregl.MapMouseEvent & {
-          features?: maplibregl.MapGeoJSONFeature[];
-        },
-      ) => {
-        if (!e.features?.length) return;
-
-        map.current!.getCanvas().style.cursor = 'pointer';
-
-        if (hoveredId !== undefined) {
-          map.current!.setFeatureState(
-            { source: 'metro-lines', id: hoveredId },
-            { hover: false },
-          );
-        }
-
-        hoveredId = e.features[0].id;
-        map.current!.setFeatureState(
-          { source: 'metro-lines', id: hoveredId },
-          { hover: true },
-        );
-
-        const lineId = e.features[0].properties.line_id as number;
-        const lineData = linesRef.current.find((l) => l.id === lineId);
-        popup
-          .setLngLat(e.lngLat)
-          .setHTML(buildPopupHTML(e.features[0].properties.name as string, lineData))
-          .addTo(map.current!);
-      };
-
-      const onMouseLeave = () => {
-        map.current!.getCanvas().style.cursor = '';
-        popup.remove();
-
-        if (hoveredId !== undefined) {
-          map.current!.setFeatureState(
-            { source: 'metro-lines', id: hoveredId },
-            { hover: false },
-          );
-        }
-        hoveredId = undefined;
-      };
-
-      map.current!.on('mousemove', 'lines-selected', onMouseMove);
-      map.current!.on('mouseleave', 'lines-selected', onMouseLeave);
-
-      // Apply initial selection state
-      const selectedIds = lines.filter((l) => l.selected).map((l) => l.id);
-      map.current!.setFilter('lines-selected', [
-        'in',
-        ['get', 'line_id'],
-        ['literal', selectedIds],
-      ]);
-    });
+    observer.observe(container);
 
     return () => {
-      map.current?.remove();
-      map.current = null;
-      isStyleLoaded.current = false;
+      observer.disconnect();
+      s.host.remove();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Sync selected lines with the map filter whenever selection changes
+  // Sync selected lines with the map filter whenever selection changes. Runs
+  // on every (re)mount too, so a remounted component re-applies its selection.
   useEffect(() => {
-    linesRef.current = lines;
-    if (!isStyleLoaded.current) return;
-    const selectedIds = lines.filter((l) => l.selected).map((l) => l.id);
-    map.current?.setFilter('lines-selected', [
-      'in',
-      ['get', 'line_id'],
-      ['literal', selectedIds],
-    ]);
+    const s = getOrCreateSingleton();
+    s.lines = lines;
+    if (!s.styleLoaded) return;
+    applySelectionFilter(s);
   }, [lines]);
 
   return <div id="lineMap" ref={mapContainer} />;

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -171,6 +171,7 @@ function getOrCreateSingleton(): MapSingleton {
 export function __resetMapForTests() {
   if (singleton == null) return;
   singleton.map.remove();
+  singleton.host.remove();
   singleton = null;
 }
 
@@ -186,6 +187,10 @@ export default function Map({ lines }: MapProps) {
 
     container.appendChild(s.host);
     s.map.resize();
+    // resize() early-returns when the container dimensions are unchanged, so on
+    // a re-attach at the same size it schedules no frame. Ask for one explicitly
+    // rather than relying on the next user interaction to repaint the canvas.
+    s.map.triggerRepaint();
 
     const observer = new ResizeObserver(() => {
       s.map.resize();


### PR DESCRIPTION
## Summary

PR B3 of the dockable-panels wave 2 (plan: `src/plans/dockable-panels.md`). Makes the MapLibre map a module-scope singleton that is **never destroyed**, so camera position, layers, and the tile cache survive React unmount/remount — dockview panel hide/show, drag-docking, and the future mobile/desktop layout switch. Standalone-correct on today's main: the map behaves exactly as it does now.

Files touched (B3-owned only): `src/components/Map.tsx`, `src/components/Map.test.tsx`, `src/components/Map.css`.

## Screenshots

Captured from the production build (`vite build`, served over plain HTTP) driven by headless Edge over CDP, with `?lines=801,802,720` so the `lines-selected` layer is exercised.

**Map panel — A Line (blue) and B Line (red) rendered over the OpenFreeMap basemap:**

<!-- SCREENSHOT: map-panel.png — drag the image here -->

**Full dashboard:**

<!-- SCREENSHOT: b3-map-full.png — drag the image here -->

> The images are attached in the review thread — `gh` has no image-upload API, so they need to be dragged into this description (or a comment). Flagging that explicitly rather than silently shipping a text-only PR.

## Diff summary

- **Map.tsx**
  - Module-scope `MapSingleton` (`host` div + `maplibregl.Map` + `styleLoaded` + latest `lines`), built lazily by `getOrCreateSingleton()`. The map is constructed with `container: host`; the `load` handler (source, `lines-all`/`lines-selected` layers, hover popup, initial filter) is a verbatim move from the old effect, except it reads `singleton.lines` instead of closing over first-mount props — so the popup and initial filter stay correct across remounts.
  - Mount effect now only attaches: `container.appendChild(host)` + `map.resize()` + `map.triggerRepaint()`; cleanup detaches the host (`host.remove()`) — `map.remove()` is never called.
  - `triggerRepaint()` is deliberate: MapLibre's `resize()` early-returns when the container dimensions are unchanged, so a re-attach at the same size would schedule no frame and the canvas would sit blank until the next user interaction.
  - `ResizeObserver` on the container calls `map.resize()` (MapLibre's `trackResize` only watches the window, not dockview sashes); disconnected on unmount.
  - Selection-sync effect unchanged in logic; because effects run on every mount, a remount re-applies the current filter without a new `load` event.
  - Test-only `__resetMapForTests()` export destroys the singleton (`map.remove()`, drop the host, null the ref) so tests stay isolated. Carries an eslint-disable for `react-refresh/only-export-components` (intentional non-component export).
- **Map.css** — new `.map-host` rule (100% × 100%, `border-radius: inherit`) for the re-parented host div; `#lineMap` (400px) and popup styles untouched, so today's layout is pixel-identical.
- **Map.test.tsx** — mock gains `resize` and `triggerRepaint`; `beforeEach` calls `__resetMapForTests()` before `vi.clearAllMocks()`. Old "removes the map on unmount" test replaced by singleton-lifecycle tests: no `remove()` on unmount, host detach on unmount, single `Map` construction across unmount/remount, `resize()` + `triggerRepaint()` after each attach, filter re-sync on remount without a new load event, and fresh-map-after-reset. All pre-existing behavioral tests kept.

## Verify gate

`npm run lint && npm run test && npm run build` — all green (0 lint problems, 291/291 tests across 16 files, tsc + vite build clean).

## Manual drive

Driven headlessly over CDP against the production build (script kept out of the repo). Observed:

- Map renders into `#lineMap > .map-host`; exactly one `.maplibregl-canvas`; basemap + both selected routes paint (see screenshot above).
- Toggling the line-selector expand control unmounts `OutputArea`/`Map` (`{!isLineSelectorExpanded && <OutputArea/>}` in App.tsx): host div and canvas fully leave the DOM (`{hosts: 0, canvases: 0}`) while the instance stays alive.
- Toggling back re-attaches the **same canvas element** (verified via a `data-probe` tag set before unmount): `{sameCanvas: true, canvases: 1, hostParent: "lineMap", contextLost: false}`. `maplibregl.Map` was constructed once for the whole session.

**Caveat — please eyeball this one in a real browser.** In headless Edge with SwiftShader, the re-attached canvas comes back *blank* (it stays blank even with `triggerRepaint()`, and even in an experiment where the host never left the document at all — so it is a software-rasterizer compositing artifact rather than a DOM-detach problem). The Claude Code embedded browser can't be used to check either: it runs with `document.hidden === true`, which suspends `requestAnimationFrame` so MapLibre never paints, and the dev server's self-signed HTTPS cert is unopenable there. So the *instance/DOM* half of the remount is verified, but the *pixels after remount* are not. A quick `npm run dev` → pan/zoom → expand-toggle round trip on a GPU browser would close that gap.

## Flags / defaults chosen

- The task suggested keeping `lines` reachable by the singleton; I moved it into the singleton object (was a per-instance `linesRef`) — required so the hover popup shows current metrics after a remount rather than first-mount data.
- `.map-host` class name chosen for the host div; the container keeps `id="lineMap"` so existing CSS/QA hooks are unchanged.
- Plan-doc contract gap noted for B2: with the singleton, rendering **two** `Map` components simultaneously would steal the host div to whichever mounted last. Fine for the planned single `map` panel (`defaultRenderer: always`), but worth knowing if a future layout ever duplicates the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
