### PR TITLE
ci: regenerate visual baselines in CI via an update-snapshots workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual re-run, with no inputs. A push made with GITHUB_TOKEN does not trigger workflows
+  # (GitHub's loop guard), so when update-snapshots.yml commits regenerated baselines to a PR
+  # branch, that PR keeps showing the run from before the commit. This trigger lets that workflow
+  # dispatch a fresh run at the branch; check runs attach to the commit SHA, so the new result
+  # shows up on the PR.
+  workflow_dispatch:
 
 # One in-flight run per ref. Superseded PR runs are cancelled; runs on main are never
 # cancelled, so every commit on the default branch keeps a complete, attributable result.

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -1,0 +1,276 @@
+name: Update snapshots
+
+# Regenerating the committed `-linux.png` baselines means running the suite inside the exact
+# Playwright container CI compares against — which locally means Docker Desktop, and that is the
+# one prerequisite this repo asks for that has nothing to do with writing the app. This workflow
+# does the same job on GitHub's runners: label a PR `update-snapshots` (or dispatch it against a
+# branch) and the baselines are regenerated, verified, and committed back to the branch.
+#
+# It is deliberately NOT triggered by a failing `e2e` run. Overwriting a baseline destroys the
+# only record of what the UI used to look like, so regeneration stays a deliberate human act —
+# see README.md § "CI went red — now what".
+
+on:
+  # The everyday path: no inputs to fill in and the branch is implied by the PR. The label is
+  # taken off again when the run finishes, so re-running is a single label add.
+  pull_request:
+    types: [labeled]
+  # The manual path, for a branch that has no PR yet — and the only way to pass a filter.
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to regenerate baselines on. Never `main`.'
+        required: true
+      filter:
+        description: 'Optional extra arguments for `playwright test`, e.g. `--project=map` or a title substring like `chart-content`. Empty regenerates every baseline.'
+        required: false
+        default: ''
+
+# One run per branch, keyed the same way whichever trigger fired.
+concurrency:
+  group: update-snapshots-${{ github.event.pull_request.head.ref || inputs.branch }}
+  cancel-in-progress: false     # a killed run can leave a branch half-updated
+
+permissions:
+  contents: write        # push the regenerated baselines
+  pull-requests: write   # remove the label when done
+  actions: write         # re-dispatch CI on the new commit
+
+jobs:
+  # Split out from `update` because a job's `container:` image is resolved before any of its
+  # steps run — the Playwright version therefore has to be known in a *previous* job. The safety
+  # guards live here too: they are much cheaper to fail before pulling a ~2GB image.
+  resolve:
+    name: Resolve target branch and Playwright version
+    # `github.event.label.name` is only set on the labeled event; the `workflow_dispatch` half of
+    # the condition is what lets a manual run through.
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'update-snapshots'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      ref: ${{ steps.target.outputs.ref }}
+      playwright-version: ${{ steps.playwright-version.outputs.version }}
+
+    steps:
+      # A fork PR is checked out with a read-only GITHUB_TOKEN, so the push at the end of
+      # `update` would fail after ~10 minutes of work. Fail immediately and say what to do
+      # instead. Every open PR is same-repo today; this guard is here for the day one isn't.
+      #
+      # The alternative — `pull_request_target`, which would run with a writable token — is
+      # deliberately not used: it would execute a fork's `npm ci` and its Playwright specs with
+      # write access to this repository.
+      - name: Reject fork pull requests
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error::Baselines cannot be pushed to a fork's branch (fork PRs get a read-only token). Regenerate locally with 'npm run test:e2e:update:linux', or ask a maintainer to run this workflow against a branch in $GITHUB_REPOSITORY — every run uploads the regenerated PNGs as an artifact, which a fork author can download and commit."
+          exit 1
+
+      # Branch names and dispatch inputs are attacker-influenced text, so they reach the shell
+      # through `env:` and are quoted at every expansion — never interpolated into the script.
+      - name: Resolve the target branch
+        id: target
+        env:
+          REF: ${{ github.event.pull_request.head.ref || inputs.branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if [ -z "$REF" ]; then
+            echo "::error::No branch to update: the 'branch' input is required for a manual run."
+            exit 1
+          fi
+          # Baselines are never rewritten on the default branch. They get there by merging a PR
+          # that regenerated them, which is what keeps the change reviewable in a diff.
+          if [ "$REF" = "main" ] || [ "$REF" = "$DEFAULT_BRANCH" ]; then
+            echo "::error::Refusing to regenerate baselines on '$REF'. Run this against a feature branch and merge the result."
+            exit 1
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "Target branch: $REF"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.ref }}
+
+      # Identical to the line in ci.yml, on purpose: the image that regenerates a baseline must
+      # be the image that later compares against it, or the fonts shift under you.
+      - name: Resolve Playwright version from the lockfile
+        id: playwright-version
+        run: |
+          version="$(jq -er '.packages["node_modules/@playwright/test"].version' package-lock.json)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "@playwright/test $version -> mcr.microsoft.com/playwright:v$version-noble"
+
+  update:
+    name: Regenerate and commit Linux baselines
+    needs: resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    container:
+      # Same image, same tag source, same reasoning as ci.yml's `e2e` job — see its comment.
+      image: mcr.microsoft.com/playwright:v${{ needs.resolve.outputs.playwright-version }}-noble
+      # Docker's default 64MB /dev/shm makes Chromium crash mid-test on full-page screenshots.
+      options: --ipc=host
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The branch itself, not the default `refs/pull/N/merge`. That ref is a detached,
+          # throwaway merge commit — committing onto it produces something with nowhere to go.
+          ref: ${{ needs.resolve.outputs.ref }}
+          # Left at the default `true`: the push at the end of this job needs the credentials
+          # checkout writes into .git/config.
+          persist-credentials: true
+
+      # The container runs as root over a checkout owned by the runner user, and git refuses to
+      # touch a repository owned by someone else ("detected dubious ownership"). actions/checkout
+      # sets this itself today, but the push below is too important to rest on that default.
+      - name: Trust the workspace checkout
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      # Same key as ci.yml's `e2e` job, so the two share one cache entry. In a container job HOME
+      # is /github/home, so `~/.npm` resolves correctly — do not hardcode /root/.npm.
+      - name: Cache npm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-container-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-container-
+
+      # As in ci.yml's `e2e` job, no setup-node: the image ships the Node that Playwright ships
+      # against. The build below therefore runs on that Node rather than .node-version's, which
+      # is fine — Vite's output is fixed by the locked toolchain in node_modules, and what the
+      # screenshots capture is the rendered app, not the bundle.
+      - name: Install dependencies
+        run: npm ci
+
+      # playwright.config.ts skips its own build when CI is set (on CI the app normally arrives
+      # as an artifact from ci.yml's `build` job), so `vite preview` needs a dist/ built here.
+      - name: Build
+        run: npm run build
+
+      - name: Toolchain
+        run: node -v && npm -v && npx playwright --version
+
+      # This can only ever write `-linux.png`: Playwright suffixes every snapshot with
+      # `process.platform`, and the other two suffixes are git-ignored anyway. `--update-snapshots`
+      # only rewrites the screenshots that actually differ, so the diff below stays honest.
+      - name: Regenerate the Linux baselines
+        env:
+          # Dispatch inputs reach the shell through env, never interpolated into the script.
+          FILTER: ${{ inputs.filter }}
+        run: |
+          # shellcheck disable=SC2086  # unquoted on purpose: a multi-word filter must split
+          npm run test:e2e:update -- $FILTER
+
+      # The reason a baseline committed by a bot is trustworthy. `--retries=0` overrides the
+      # config's `retries: 2` (which CI otherwise gets), so the freshly-written screenshots have
+      # to reproduce on the very first attempt. Without it, a canvas that settles differently
+      # every other run would be baked into a baseline and hidden behind a retry — turning this
+      # workflow into a machine for committing flake.
+      - name: Verify the new baselines reproduce with no retries
+        env:
+          FILTER: ${{ inputs.filter }}
+        run: |
+          # shellcheck disable=SC2086  # unquoted on purpose: a multi-word filter must split
+          npx playwright test --retries=0 $FILTER
+
+      # Two outcomes are fine: nothing changed (the baselines were already current), or only
+      # snapshot PNGs changed. Anything else means the run modified tracked source, which is not
+      # what this workflow is for and must not ride along in a `test(e2e):` commit.
+      - name: Inspect the working tree
+        id: diff
+        run: |
+          # -uall lists untracked files individually. Without it a brand-new snapshot directory
+          # (what a newly-added spec produces) collapses to one `?? e2e/foo.spec.ts-snapshots/`
+          # entry, which the .png check below would reject as an unexpected change.
+          status="$(git status --porcelain -uall)"
+          if [ -z "$status" ]; then
+            echo "baselines already current — nothing to commit"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "$status"
+          # Strip the two status columns and the separating space to get each path. Renames are
+          # not a thing a screenshot run produces, so this is enough.
+          unexpected="$(echo "$status" | cut -c4- | grep -vE '^"?e2e/.+-snapshots/.+\.png"?$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "::error::Regeneration touched files outside e2e/**/*-snapshots/*.png; refusing to commit."
+            echo "$unexpected"
+            exit 1
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      # `always()`: the interesting case is the failed one. If the verification pass above went
+      # red, these are the *-actual.png / *-diff.png and the trace that explain why — and for a
+      # fork PR, downloading this artifact and committing the PNGs by hand is the whole fallback.
+      - name: Upload regenerated baselines and the Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-snapshots
+          path: |
+            e2e/**/*-snapshots/*.png
+            playwright-report/
+            test-results/
+          retention-days: 14
+          if-no-files-found: ignore
+          overwrite: true
+
+      - name: Commit and push the regenerated baselines
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          REF: ${{ needs.resolve.outputs.ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A -- e2e
+          git commit \
+            --message 'test(e2e): regenerate Linux visual baselines' \
+            --message "Regenerated in the pinned Playwright container and verified with a clean --retries=0 run by $RUN_URL"
+          # Never --force: if the branch moved while this ran, the push is rejected and the run
+          # goes red rather than quietly dropping whatever landed in between.
+          git push origin "HEAD:refs/heads/$REF"
+
+      # `gh` is not installed in the Playwright image (it ships Node, browsers, git and curl and
+      # nothing else), so the two GitHub API calls below go through actions/github-script, which
+      # runs on the Node the runner injects into the container.
+      - name: Re-run CI on the pushed commit
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        env:
+          BRANCH: ${{ needs.resolve.outputs.ref }}
+        with:
+          script: |
+            // A push authenticated with GITHUB_TOKEN does not trigger workflows — GitHub's loop
+            // guard — so the PR would go on showing the CI run from *before* the baselines were
+            // committed. ci.yml carries a bare `workflow_dispatch:` for exactly this call; the
+            // check runs it produces attach to the new commit SHA and surface on the PR.
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              ref: process.env.BRANCH,
+            });
+            core.info(`Dispatched ci.yml at ${process.env.BRANCH}`);
+
+      # `always()`: the label comes off even when the run failed, so a retry is one label add
+      # rather than remove-then-re-add (re-adding a label that is already there emits no event).
+      - name: Remove the update-snapshots label
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'update-snapshots',
+              });
+            } catch (error) {
+              // 404: someone took it off by hand while this ran. Not worth failing over.
+              if (error.status !== 404) throw error;
+              core.info('Label was already removed.');
+            }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The general process of loading and transforming relevant data is as follows:
 - Node.js 22 — the repo pins `22.23.2` in [`.node-version`](.node-version), which `fnm`/`nvs`/`asdf` read automatically. CI uses the same file.
 - npm
 - Python 3 — only for the data-processing scripts (see [`scripts/README.md`](scripts/README.md))
-- Docker — only for regenerating Linux visual-regression baselines (see [End-to-end tests](#end-to-end--visual-regression-tests))
+- Docker — optional. Only needed to regenerate Linux visual-regression baselines on your own machine; CI can do it for you instead (see [End-to-end tests](#end-to-end--visual-regression-tests))
 
 ### Local development
 
@@ -89,10 +89,10 @@ Playwright names each snapshot after the OS that captured it, and font rendering
 
 | Suffix | Used by | In git? | Regenerate with |
 | --- | --- | --- | --- |
-| `-linux.png` | CI — the only baselines that gate a PR | committed | `npm run test:e2e:update:linux` |
+| `-linux.png` | CI — the only baselines that gate a PR | committed | `npm run test:e2e:update:linux`, or the `update-snapshots` label |
 | `-win32.png` / `-darwin.png` | your local runs | git-ignored, per-developer scratch | `npm run test:e2e:update` |
 
-**When a UI change legitimately alters the screenshots, regenerate the Linux set and commit it:** `npm run test:e2e:update:linux`. That's the only baseline command a PR needs. It shells out to the same Playwright Docker image CI uses (see [`scripts/README.md`](scripts/README.md#update_linux_snapshotspy)), so it needs Docker Desktop running.
+**When a UI change legitimately alters the screenshots, regenerate the Linux set and commit it:** `npm run test:e2e:update:linux`. That's the only baseline command a PR needs. It shells out to the same Playwright Docker image CI uses (see [`scripts/README.md`](scripts/README.md#update_linux_snapshotspy)), so it needs Docker Desktop running — or you can skip Docker entirely and let CI do it, [below](#or-let-ci-regenerate-them-for-you).
 
 Your own platform's baselines are yours alone — the first local `npm run test:e2e` writes them, and nothing you do to them can turn CI red.
 
@@ -101,6 +101,24 @@ The map baselines in [`e2e/map.spec.ts-snapshots/`](e2e/map.spec.ts-snapshots/) 
 ```bash
 npm run test:e2e:update:linux -- --project=map
 ```
+
+#### Or let CI regenerate them for you
+
+Docker Desktop is the only prerequisite in this repo that has nothing to do with writing the app, so [`.github/workflows/update-snapshots.yml`](.github/workflows/update-snapshots.yml) does the same work in the same container, on GitHub's runners:
+
+- **On a pull request:** add the `update-snapshots` label. The workflow regenerates the baselines, commits them to your branch as `github-actions[bot]`, and takes the label off again.
+- **On any branch:** Actions → **Update snapshots** → **Run workflow**, and give it a branch. Its optional `filter` input is passed straight through to `playwright test`, so `--project=map` or a title substring like `chart-content` narrows what gets rewritten — the equivalent of the `--` arguments above.
+
+Two things happen after the screenshots are rewritten and before anything is committed:
+
+1. **The suite is re-run against the new baselines with `--retries=0`.** On CI the config allows `retries: 2`, which would let a render that only settles on the second attempt become a committed baseline. This pass is what makes a bot-authored baseline trustworthy: it has to reproduce on the very first try.
+2. **The diff is checked.** If anything outside `e2e/**/*-snapshots/*.png` is dirty, the run fails instead of committing it. If nothing changed at all, the run says so and succeeds — the baselines were already current.
+
+Because a push authenticated with `GITHUB_TOKEN` doesn't trigger workflows, the run then dispatches [CI](.github/workflows/ci.yml) at your branch itself, so the PR shows a real result for the new commit rather than the stale pre-commit one. The regenerated PNGs and the Playwright report are uploaded as a run artifact either way — which is also the fallback for fork PRs, since those are checked out with a read-only token and are rejected up front.
+
+The label comes off even when the run fails, so retrying is a single label add.
+
+**Nothing triggers this workflow automatically, by design.** It is not wired to a failing `e2e` run: regenerating a baseline overwrites the only record of what the UI used to look like, so it stays something a human asks for after looking at the diff.
 
 #### The map suite
 
@@ -132,24 +150,26 @@ Uses ESLint with TypeScript, React hooks, and React refresh plugins. Fix lint er
 
 The app is built once and handed to `e2e` as an artifact, the container ships the browsers already installed, and superseded PR runs are cancelled automatically. The container tag is derived from `package-lock.json` at run time, so it can never drift from the installed `@playwright/test` — and `npm run test:e2e:update:linux` resolves the same tag from the same file, which is what makes locally-generated baselines match CI.
 
+There is a second workflow, [`update-snapshots.yml`](.github/workflows/update-snapshots.yml), which regenerates the committed Linux baselines in that same container and commits them to your branch — see [Or let CI regenerate them for you](#or-let-ci-regenerate-them-for-you). It is why `ci.yml` also carries a bare `workflow_dispatch:` trigger: a push made with `GITHUB_TOKEN` doesn't start a workflow, so the bot's commit needs CI dispatched at the branch explicitly.
+
 **When `e2e` fails, download the `playwright-report` artifact** from the run's summary page. It contains `playwright-report/index.html` (open it in a browser) and `test-results/`, which holds the `*-expected.png` / `*-actual.png` / `*-diff.png` triplets.
 
 ### CI went red — now what
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| `e2e`: `A snapshot doesn't exist at …-linux.png` | You added a test, a viewport/project, or renamed a snapshot | `npm run test:e2e:update:linux`, then commit the new `-linux.png` files. |
+| `e2e`: `A snapshot doesn't exist at …-linux.png` | You added a test, a viewport/project, or renamed a snapshot | `npm run test:e2e:update:linux`, then commit the new `-linux.png` files. No Docker? Label the PR `update-snapshots` and let CI commit them. |
 | Locally: `A snapshot doesn't exist at …-win32.png`, then it passes on a re-run | **Expected, not a bug.** Windows baselines aren't committed, so your first run on a fresh clone writes its own | Nothing. Re-run `npm run test:e2e`. The written `-win32.png` files are git-ignored. |
-| `e2e`: pixel diff, **and you meant to change the UI** | Baselines are stale | Regenerate with `npm run test:e2e:update:linux` and commit. Put a screenshot of the new UI in the PR description. |
+| `e2e`: pixel diff, **and you meant to change the UI** | Baselines are stale | Regenerate with `npm run test:e2e:update:linux` and commit, or label the PR `update-snapshots` to have CI do it. Put a screenshot of the new UI in the PR description either way. |
 | `e2e`: pixel diff, **and you didn't touch the UI** | A real regression, or a non-deterministic render | Download the artifact and look at `*-diff.png` before doing anything else. **Don't regenerate baselines to make it green** — that deletes the evidence. |
 | `e2e` fails on `desktop` but not `mobile` (or vice versa) | Responsive-layout regression at 1280px or 390px | Reproduce with `npm run test:e2e -- --project=mobile`; use `npm run test:e2e:ui` to step through it. |
 | `e2e` is flaky — fails once, passes on retry | A canvas hadn't finished rendering | The config already pins `workers: 1`, `retries: 2` and `animations: 'disabled'`. If you added an animated component, `await` a settled state in the spec rather than loosening `maxDiffPixelRatio`. |
 | `e2e`: `webServer` timed out after 180s | `dist/` was missing/empty, or port 4173 was busy | Check that `build` uploaded `dist`. Locally, kill anything on 4173 — `vite preview` silently moves to 4174, which makes Playwright wait out the full timeout. |
-| `e2e`: browser not found, or a version mismatch | `@playwright/test` was upgraded | Nothing to change in `ci.yml`; the container follows the lockfile. **But a new browser build re-renders text**, so regenerate the Linux baselines in the same PR. |
+| `e2e`: browser not found, or a version mismatch | `@playwright/test` was upgraded | Nothing to change in `ci.yml`; the container follows the lockfile. **But a new browser build re-renders text**, so regenerate the Linux baselines in the same PR — locally, or with the `update-snapshots` label (the workflow resolves the new image from the same lockfile). |
 | `build`: `tsc -b` errors in `e2e/` or `playwright.config.ts` | `tsconfig.json` references `tsconfig.e2e.json` | Fix the types. E2E code is part of the build, not a side project. |
 | `build` passes locally but fails in CI | Node version mismatch | CI reads [`.node-version`](.node-version) (`22.23.2`). Match it locally with `fnm use`. |
 | You added a page, route, or major component | It has no visual coverage | Add a test to [`e2e/visual.spec.ts`](e2e/visual.spec.ts) reusing the existing `gotoDashboard()` helper, then generate its Linux baselines. Map changes go in [`e2e/map.spec.ts`](e2e/map.spec.ts) via `gotoMap()` instead. |
-| `map`: pixel diff after a line-data update | New/changed geometry in `public/metro_lines.geojson` legitimately moves the lines | `npm run test:e2e:update:linux -- --project=map`. |
+| `map`: pixel diff after a line-data update | New/changed geometry in `public/metro_lines.geojson` legitimately moves the lines | `npm run test:e2e:update:linux -- --project=map`, or dispatch **Update snapshots** with `filter: --project=map`. |
 | `map`: the screenshot shows a real basemap, or the layer-stack assertion sees ~100 layers | A map request escaped the route stub in `e2e/map.spec.ts` | Fix the stub. Don't loosen `maxDiffPixelRatio` — with the basemap gone this suite is byte-stable. |
 | `map`: `window.__metroMap` is undefined | The test seam was removed from `src/components/Map.tsx` | Put it back, or give the spec another handle on the instance. It's the only way to await a WebGL canvas. |
 | You added a build-time env var (`VITE_*`) | Only the `build` job compiles the app | Add it to that job's `env:`. (`VITE_MAPTILER_KEY` is optional — the app falls back to OpenFreeMap — so no secret is required today.) |


### PR DESCRIPTION
## Where this sits

A new `.github/workflows/update-snapshots.yml`, one trigger added to `ci.yml`, and the README section that tells a contributor how to regenerate baselines. No app code.

## What this changes

Regenerating the committed `*-linux.png` baselines needs the exact Playwright container CI compares against, which locally means `npm run test:e2e:update:linux` and a running Docker Desktop — the only prerequisite in this repo that has nothing to do with writing the app, and the thing that stops a contributor landing a legitimate UI change. The workflow does the same work in the same pinned container on GitHub's runners, triggered either by labelling a PR `update-snapshots` (branch implied, nothing to fill in, label removed when the run finishes) or by **Actions → Update snapshots → Run workflow** for a branch with no PR, whose optional `filter` input passes straight through to `playwright test` so `--project=map` or a title substring narrows what gets rewritten. Nothing fires this on a failing `e2e` run: regenerating a baseline overwrites the only record of what the UI used to look like, so the README's "that deletes the evidence" warning stands unchanged and regeneration stays a deliberate human act after looking at the diff.

## What to check

- `update-snapshots.yml:166-176` — the verification re-run at an explicit `--retries=0`, overriding the config's `retries: 2` on CI. Without it a canvas that only settles on the second attempt would be written into a baseline and then pass behind a retry, making the workflow a machine for committing flake. That single flag is why a bot-authored baseline is trustworthy.
- `update-snapshots.yml:187` — the commit guard. Empty `git status --porcelain -uall` logs "baselines already current" and succeeds without committing; anything dirty outside `e2e/**/*-snapshots/*.png` fails rather than smuggling a source change into a `test(e2e):` commit. `-uall` matters, because without it a brand-new snapshot directory — exactly what adding a spec produces — collapses to one `?? …-snapshots/` entry and trips the guard.
- `update-snapshots.yml:43` and `:102` — two jobs because a job's `container:` image is resolved before any step runs. `resolve` holds the guards and reads the Playwright version from `package-lock.json` with the same `jq -er` line `ci.yml` uses (`:98`); `update` runs in `mcr.microsoft.com/playwright:v<that version>-noble` with `--ipc=host` and shares `ci.yml`'s `~/.npm` cache key.
- `update-snapshots.yml:62` — fork PRs are rejected up front with an actionable `::error::` rather than handled via `pull_request_target`, which would run a fork's `npm ci` and specs with a writable token against this repo. Every run uploads the PNGs as an artifact (`:209`), which is the fork author's fallback.
- `update-snapshots.yml:232` and `:80` — never `--force`, and never the default branch: if the branch moved mid-run the push is rejected and the run goes red.
- `update-snapshots.yml:248` and the one-line `ci.yml` change — a push authenticated with `GITHUB_TOKEN` does not trigger workflows, so without a bare `workflow_dispatch:` on `ci.yml` the PR would go on showing the CI run from before the bot's commit. Check runs attach to the SHA, so the dispatched run surfaces on the PR. `ci.yml`'s jobs are untouched.
- No `${{ }}` reaches any `run:` script; branch names and `filter` arrive through `env:` and are quoted at every expansion except the two deliberate `SC2086` splits at `:163` and `:175`. Permissions are the minimum three at `:34`.

## Before you merge

The label does not exist yet, and this PR deliberately does not create it or run the workflow. Create it, and confirm **Settings → Actions → General → Workflow permissions** is *Read and write*, or the workflow-level `contents: write` cannot be granted and the push 403s. The workflow only runs from a branch that contains it, so PRs branched before this merges need a rebase onto `main` before the label does anything.

```bash
gh label create update-snapshots --description "Regenerate the committed Linux visual baselines in CI" --color 1D76DB --repo streetsforall/metro_ridership_app
```

<!-- Commands were current on 2026-08-22; CONTRIBUTING.md is authoritative if they have drifted. -->

- [ ] `npm run lint`, `npm run test` and `npm run build` pass — `lint` and `build` are clean; `test` not run, and no app code is touched
- [ ] `update-snapshots` label created and workflow permissions set to read/write
- [x] `actionlint` unavailable on this machine, so both workflows were parsed with PyYAML, every `run:` block syntax-checked with `bash -n`, the no-`${{ }}`-in-shell and no-hardcoded-Playwright-version rules asserted, and the diff guard's filter unit-tested against tracked, untracked and mixed working trees
- [x] No exported symbol renamed or deleted
- [x] No diagram source changed
- [x] No UI change, so no baselines regenerated here
