### PR TITLE
feat(ridership): add buildRidershipView and its unit test

### DIFF
--- a/src/ridership/buildRidershipView.test.ts
+++ b/src/ridership/buildRidershipView.test.ts
@@ -1,0 +1,538 @@
+import { describe, it, expect } from 'vitest';
+import { buildRidershipView, type LineSelection } from './buildRidershipView';
+import type { DayOfWeek, RidershipRecord } from '../@types/metrics.types';
+import type { TransitEvent } from '../@types/events.types';
+
+/**
+ * Local fixture helpers. Deliberately not shared builders — consolidating the
+ * suite's six near-identical factories is #104, kept separate so these diffs stay
+ * skimmable for behaviour drift.
+ */
+const makeRecord = (
+  year: number,
+  month: number,
+  line_name: number,
+  overrides: Partial<RidershipRecord> = {},
+): RidershipRecord => ({
+  year,
+  month,
+  line_name,
+  est_wkday_ridership: 1000,
+  est_sat_ridership: 600,
+  est_sun_ridership: 400,
+  ...overrides,
+});
+
+const makeEvent = (
+  id: string,
+  date: string,
+  line_ids: number[],
+): TransitEvent => ({
+  id,
+  date,
+  line_ids,
+  title: id,
+  description: id,
+  category: 'service_change',
+});
+
+/**
+ * Same shape as `App.test.tsx`'s fixture, so the assertions migrated from there
+ * keep their meaning:
+ *   807 (K Line) — 2019-01, 2022-01, 2026-01
+ *   806 (L Line) — 2022-01 only; inserted before K so numeric key order differs
+ *                  from alphabetical order
+ *   804 (E Line) — 2020-08 → 2026-01, the long series
+ *   805 (D Line) — 2025-07, 2026-01 only. D sorts before E alphabetically, so the
+ *                  short series is the *first* dataset — the shape that used to
+ *                  scramble the x-axis.
+ */
+const RECORDS: RidershipRecord[] = [
+  makeRecord(2019, 1, 807, {
+    est_wkday_ridership: 1000,
+    est_sat_ridership: 600,
+    est_sun_ridership: 400,
+  }),
+  makeRecord(2020, 8, 804, {
+    est_wkday_ridership: 4000,
+    est_sat_ridership: 2000,
+    est_sun_ridership: 1000,
+  }),
+  makeRecord(2022, 1, 807, {
+    est_wkday_ridership: 5000,
+    est_sat_ridership: 3000,
+    est_sun_ridership: 2000,
+  }),
+  makeRecord(2022, 1, 806, {
+    est_wkday_ridership: 8000,
+    est_sat_ridership: 5000,
+    est_sun_ridership: 3000,
+  }),
+  makeRecord(2022, 1, 804, {
+    est_wkday_ridership: 4400,
+    est_sat_ridership: 2200,
+    est_sun_ridership: 1100,
+  }),
+  makeRecord(2025, 7, 804, {
+    est_wkday_ridership: 4800,
+    est_sat_ridership: 2400,
+    est_sun_ridership: 1200,
+  }),
+  makeRecord(2025, 7, 805, {
+    est_wkday_ridership: 700,
+    est_sat_ridership: 350,
+    est_sun_ridership: 175,
+  }),
+  makeRecord(2026, 1, 807, {
+    est_wkday_ridership: 9000,
+    est_sat_ridership: 7000,
+    est_sun_ridership: 5000,
+  }),
+  makeRecord(2026, 1, 804, {
+    est_wkday_ridership: 5200,
+    est_sat_ridership: 2600,
+    est_sun_ridership: 1300,
+  }),
+  makeRecord(2026, 1, 805, {
+    est_wkday_ridership: 900,
+    est_sat_ridership: 450,
+    est_sun_ridership: 225,
+  }),
+];
+
+/** Window bounds are parsed the way the dashboard hook parses them: `new Date(year, month - 1)`. */
+const month = (year: number, oneBasedMonth: number) =>
+  new Date(year, oneBasedMonth - 1);
+
+/** A window wide enough to hold every fixture record. */
+const WIDE = { startDate: month(2018, 1), endDate: month(2027, 1) };
+
+const build = (over: Partial<Parameters<typeof buildRidershipView>[0]> = {}) =>
+  buildRidershipView({
+    records: RECORDS,
+    lines: [],
+    startDate: WIDE.startDate,
+    endDate: WIDE.endDate,
+    dayOfWeek: 'est_wkday_ridership',
+    includeAggregate: false,
+    // Default to no events so dataset-focused cases aren't perturbed by the
+    // bundled transit-events.json.
+    events: [],
+    ...over,
+  });
+
+const K: LineSelection = { id: 807, selected: true };
+const L: LineSelection = { id: 806, selected: true };
+const E: LineSelection = { id: 804, selected: true };
+const D: LineSelection = { id: 805, selected: true };
+
+describe('buildRidershipView — datasets follow the lines[] order', () => {
+  it('follows the given lines[] order, not record-encounter order', () => {
+    // 806 (L) appears before 807 (K) in RECORDS and is numerically smaller, but
+    // `lines` is the ordering authority — alphabetical, K before L.
+    const { datasets } = build({ lines: [K, L] });
+
+    expect(datasets.map((ds) => ds.label)).toEqual(['K Line', 'L Line']);
+  });
+
+  it('reverses when lines[] reverses — nothing else decides the order', () => {
+    const { datasets } = build({ lines: [L, K] });
+
+    expect(datasets.map((ds) => ds.label)).toEqual(['L Line', 'K Line']);
+  });
+});
+
+describe('buildRidershipView — line selection', () => {
+  it('produces no datasets when no lines are selected', () => {
+    const { datasets, months } = build({
+      lines: [{ id: 807, selected: false }],
+    });
+
+    expect(datasets).toHaveLength(0);
+    expect(months).toEqual([]);
+  });
+
+  it('produces one dataset per selected line', () => {
+    const { datasets } = build({ lines: [K, { id: 806, selected: false }] });
+
+    expect(datasets).toHaveLength(1);
+    expect(datasets[0].label).toBe('K Line');
+  });
+
+  it('assigns the correct brand colour to each line', () => {
+    const { datasets } = build({ lines: [K, L] });
+
+    const kLine = datasets.find((ds) => ds.label === 'K Line');
+    const lLine = datasets.find((ds) => ds.label === 'L Line');
+
+    expect(kLine?.borderColor).toBe('#e56db1'); // K Line pink
+    expect(lLine?.borderColor).toBe('#f9a825'); // L Line gold
+  });
+});
+
+describe('buildRidershipView — day of week', () => {
+  // Selecting a day-of-week does not filter records; it selects which field of
+  // each record is read.
+  const at2022 = (dayOfWeek: DayOfWeek) =>
+    build({
+      lines: [K],
+      dayOfWeek,
+      startDate: month(2021, 1),
+      endDate: month(2024, 1),
+    }).datasets[0].data[0].stat;
+
+  it('reads est_wkday_ridership for weekdays', () => {
+    expect(at2022('est_wkday_ridership')).toBe(5000);
+  });
+
+  it('reads est_sat_ridership for Saturday', () => {
+    expect(at2022('est_sat_ridership')).toBe(3000);
+  });
+
+  it('reads est_sun_ridership for Sunday', () => {
+    expect(at2022('est_sun_ridership')).toBe(2000);
+  });
+});
+
+describe('buildRidershipView — the Month Window', () => {
+  it('excludes records before the start and after the end', () => {
+    // 2019-01 is before the start, 2026-01 after the end; only 2022-01 survives.
+    const { datasets } = build({
+      lines: [K],
+      startDate: month(2021, 1),
+      endDate: month(2024, 1),
+    });
+
+    expect(datasets[0].data).toHaveLength(1);
+    expect(datasets[0].data[0].stat).toBe(5000);
+  });
+
+  it('includes every record when the window is wide enough', () => {
+    const { datasets } = build({ lines: [K] });
+
+    expect(datasets[0].data).toHaveLength(3);
+  });
+
+  it('produces no dataset for a selected line with no records in the window', () => {
+    const { datasets, byLine } = build({
+      lines: [K],
+      startDate: month(2023, 6),
+      endDate: month(2024, 6),
+    });
+
+    expect(datasets).toHaveLength(0);
+    // The line is absent from the grouping entirely, so there is no Selection
+    // Snapshot for the dataset loop to filter on.
+    expect(byLine[807]).toBeUndefined();
+  });
+
+  /**
+   * The boundary rule ADR-0001 depends on. With start = 2022-01 and end =
+   * 2024-01, a record at calendar-month ordinal R is included when
+   * S <= R <= E - 2 — so the window is 2022-01 … 2023-11 inclusive. The start
+   * month is in; the end month **and the month immediately before it** are out.
+   * This is intended. Do not "fix" it.
+   */
+  describe('boundaries (start 2022-01, end 2024-01)', () => {
+    const windowed = (year: number, monthOfYear: number) =>
+      buildRidershipView({
+        records: [makeRecord(year, monthOfYear, 807)],
+        lines: [K],
+        startDate: month(2022, 1),
+        endDate: month(2024, 1),
+        dayOfWeek: 'est_wkday_ridership',
+        includeAggregate: false,
+        events: [],
+      }).datasets.length;
+
+    it('excludes the month before the start (2021-12)', () => {
+      expect(windowed(2021, 12)).toBe(0);
+    });
+
+    it('includes the start month itself (2022-01)', () => {
+      expect(windowed(2022, 1)).toBe(1);
+    });
+
+    it('includes E − 2 (2023-11)', () => {
+      expect(windowed(2023, 11)).toBe(1);
+    });
+
+    it('excludes E − 1 (2023-12)', () => {
+      expect(windowed(2023, 12)).toBe(0);
+    });
+
+    it('excludes the end month itself (2024-01)', () => {
+      expect(windowed(2024, 1)).toBe(0);
+    });
+  });
+});
+
+describe('buildRidershipView — the Aggregate Series', () => {
+  it('is absent unless requested', () => {
+    const { datasets } = build({ lines: [K, L] });
+
+    expect(datasets.map((ds) => ds.label)).not.toContain('Aggregate');
+  });
+
+  it('is present and last when requested', () => {
+    const { datasets } = build({ lines: [K, L], includeAggregate: true });
+
+    expect(datasets).toHaveLength(3);
+    expect(datasets[datasets.length - 1].label).toBe('Aggregate');
+  });
+
+  it('equals the per-month sum of the selected lines', () => {
+    const { datasets } = build({
+      lines: [K, L],
+      includeAggregate: true,
+      startDate: month(2021, 1),
+      endDate: month(2024, 1),
+    });
+
+    const kLine = datasets.find((ds) => ds.label === 'K Line');
+    const lLine = datasets.find((ds) => ds.label === 'L Line');
+    const aggregate = datasets.find((ds) => ds.label === 'Aggregate');
+
+    // 2022-01: K weekday = 5000, L weekday = 8000 → aggregate = 13000
+    expect(aggregate!.data[0].stat).toBe(
+      kLine!.data[0].stat! + lLine!.data[0].stat!,
+    );
+    expect(aggregate!.data[0].stat).toBe(13000);
+  });
+});
+
+describe('buildRidershipView — the shared Month Axis', () => {
+  // Regression #86-adjacent: the axis used to be taken from datasets[0] alone. D
+  // Line sorts first and covers far fewer months than E Line, so the axis became
+  // D Line's months and Chart.js appended E Line's remaining months to the *end*
+  // — an x-axis that jumped from 2026 back to 2020, with a stroke across the plot.
+  const bothRail = {
+    lines: [D, E],
+    startDate: month(2020, 1),
+    endDate: month(2027, 1),
+  };
+
+  it('spans the chronological union of both lines months', () => {
+    const { months } = build(bothRail);
+
+    expect(months).toEqual(['2020 8', '2022 1', '2025 7', '2026 1']);
+  });
+
+  it('gives every dataset the same time sequence as the axis', () => {
+    const { months, datasets } = build(bothRail);
+
+    for (const dataset of datasets)
+      expect(dataset.data.map((d) => d.time)).toEqual(months);
+  });
+
+  it('nulls the months the short line does not cover', () => {
+    const { datasets } = build(bothRail);
+
+    const dLine = datasets.find((ds) => ds.label === 'D Line');
+    // Gaps, not points shifted onto the front of the axis — and never 0.
+    expect(dLine?.data.map((d) => d.stat)).toEqual([null, null, 700, 900]);
+  });
+
+  it('keeps the long line aligned to its own months', () => {
+    const { datasets } = build(bothRail);
+
+    const eLine = datasets.find((ds) => ds.label === 'E Line');
+    expect(eLine?.data.map((d) => d.stat)).toEqual([4000, 4400, 4800, 5200]);
+  });
+
+  it('sums the aggregate by month rather than by array index', () => {
+    const { datasets } = build({ ...bothRail, includeAggregate: true });
+
+    const aggregate = datasets.find((ds) => ds.label === 'Aggregate');
+    // Months only E Line reports total E Line alone — a line with no record must
+    // not be counted as a zero and drag the total down.
+    expect(aggregate?.data.map((d) => d.stat)).toEqual([
+      4000,
+      4400,
+      4800 + 700,
+      5200 + 900,
+    ]);
+  });
+});
+
+describe('buildRidershipView — data point shape', () => {
+  it('formats time as "year month" and carries both time and stat', () => {
+    const { datasets } = build({
+      lines: [K],
+      startDate: month(2021, 1),
+      endDate: month(2024, 1),
+    });
+
+    const point = datasets[0].data[0];
+    expect(point.time).toBe('2022 1');
+    expect(point).toHaveProperty('time');
+    expect(point).toHaveProperty('stat');
+  });
+});
+
+describe('buildRidershipView — Consolidated Ridership', () => {
+  it('groups records by line and records the Selection Snapshot', () => {
+    const { byLine } = build({ lines: [K, { id: 806, selected: false }] });
+
+    expect(byLine[807].selected).toBe(true);
+    expect(byLine[807].ridershipRecords).toHaveLength(3);
+    // Grouped even when unselected — the snapshot is what the dataset loop reads.
+    expect(byLine[806].selected).toBe(false);
+    expect(byLine[806].ridershipRecords).toHaveLength(1);
+  });
+});
+
+describe('buildRidershipView — the Event Window', () => {
+  // The Event Window is inclusive on both ends and correctly 1-based. It
+  // genuinely disagrees with the Month Window pinned above — with the same
+  // 2022-01 → 2024-01 bounds, a record at 2023-12 is *out* of the Month Window
+  // while an event at 2024-01 is *in* the Event Window. That divergence is
+  // deliberate and preserved.
+  const eventWindow = {
+    lines: [K],
+    startDate: month(2022, 1),
+    endDate: month(2024, 1),
+  };
+
+  it('includes an event exactly at the start month', () => {
+    const { events } = build({
+      ...eventWindow,
+      events: [makeEvent('at-start', '2022-01', [807])],
+    });
+
+    expect(events.map((e) => e.id)).toEqual(['at-start']);
+  });
+
+  it('includes an event exactly at the end month — unlike the Month Window', () => {
+    const { events, datasets } = build({
+      ...eventWindow,
+      records: [makeRecord(2024, 1, 807)],
+      events: [makeEvent('at-end', '2024-01', [807])],
+    });
+
+    expect(events.map((e) => e.id)).toEqual(['at-end']);
+    // Same bounds, same month: the record at 2024-01 is excluded. The two
+    // windows disagree on purpose.
+    expect(datasets).toHaveLength(0);
+  });
+
+  it('excludes an event one month before the start', () => {
+    const { events } = build({
+      ...eventWindow,
+      events: [makeEvent('before', '2021-12', [807])],
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it('excludes an event one month after the end', () => {
+    const { events } = build({
+      ...eventWindow,
+      events: [makeEvent('after', '2024-02', [807])],
+    });
+
+    expect(events).toEqual([]);
+  });
+});
+
+describe('buildRidershipView — event selection filtering', () => {
+  const inWindow = {
+    lines: [K],
+    startDate: month(2022, 1),
+    endDate: month(2024, 1),
+  };
+
+  it('returns a system-wide event (line_ids: []) regardless of selection', () => {
+    const { events } = build({
+      ...inWindow,
+      lines: [{ id: 807, selected: false }],
+      events: [makeEvent('system-wide', '2022-06', [])],
+    });
+
+    expect(events.map((e) => e.id)).toEqual(['system-wide']);
+  });
+
+  it('returns an event whose line_ids intersect the selection, and not one that does not', () => {
+    const { events } = build({
+      ...inWindow,
+      events: [
+        makeEvent('mine', '2022-06', [807, 806]),
+        makeEvent('not-mine', '2022-07', [806]),
+      ],
+    });
+
+    expect(events.map((e) => e.id)).toEqual(['mine']);
+  });
+
+  it('sorts events ascending by date', () => {
+    const { events } = build({
+      ...inWindow,
+      events: [
+        makeEvent('third', '2023-05', [807]),
+        makeEvent('first', '2022-02', [807]),
+        makeEvent('second', '2022-11', [807]),
+      ],
+    });
+
+    expect(events.map((e) => e.id)).toEqual(['first', 'second', 'third']);
+  });
+
+  it('returns an event on a selected line that has no records in the window', () => {
+    // The event filter reads the *live* selection, not the Selection Snapshot the
+    // datasets filter on. A line with nothing to draw still gets its events.
+    const { datasets, events } = build({
+      ...inWindow,
+      records: [makeRecord(2019, 1, 807)],
+      events: [makeEvent('still-shows', '2022-06', [807])],
+    });
+
+    expect(datasets).toHaveLength(0);
+    expect(events.map((e) => e.id)).toEqual(['still-shows']);
+  });
+
+  it('defaults to the bundled transit-events.json when no events are given', () => {
+    const { events } = buildRidershipView({
+      records: RECORDS,
+      lines: [K],
+      startDate: month(2022, 1),
+      endDate: month(2024, 1),
+      dayOfWeek: 'est_wkday_ridership',
+      includeAggregate: false,
+    });
+
+    // The K Line's Regional Connector opening (2023-06) is in the bundled data
+    // and inside this window.
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events)
+      expect(
+        event.line_ids.length === 0 || event.line_ids.includes(807),
+      ).toBe(true);
+  });
+});
+
+describe('buildRidershipView — the empty view', () => {
+  it('yields empty months, datasets and byLine while records are null', () => {
+    const { months, datasets, byLine } = build({ records: null, lines: [K, L] });
+
+    expect(months).toEqual([]);
+    expect(datasets).toEqual([]);
+    expect(byLine).toEqual({});
+  });
+
+  it('still filters and returns events while records are null', () => {
+    // The events derivation does not depend on records — matching App today,
+    // where the events memo has no ridershipRecords dependency.
+    const { events } = build({
+      records: null,
+      lines: [K],
+      startDate: month(2022, 1),
+      endDate: month(2024, 1),
+      events: [
+        makeEvent('in-window', '2022-06', [807]),
+        makeEvent('out-of-window', '2030-01', [807]),
+      ],
+    });
+
+    expect(events.map((e) => e.id)).toEqual(['in-window']);
+  });
+});

--- a/src/ridership/buildRidershipView.ts
+++ b/src/ridership/buildRidershipView.ts
@@ -1,0 +1,198 @@
+import { type ChartDataset } from 'chart.js';
+import {
+  alignToMonthAxis,
+  buildAggregateSeries,
+  buildMonthAxis,
+} from './chartData';
+import { getLineColor, getLineNames } from '../utils/lines';
+import transitEventsData from '../data/transit-events.json';
+import type { CustomChartData } from '../@types/chart.types';
+import type { TransitEvent } from '../@types/events.types';
+import type {
+  ConsolidatedRidership,
+  DayOfWeek,
+  RidershipRecord,
+} from '../@types/metrics.types';
+
+/**
+ * The minimum a caller must state about the lines. `Line` satisfies this
+ * structurally, so callers pass `lines` unchanged — but this module cannot reach
+ * the derived metrics written back onto `Line`, which is what keeps that
+ * write-back cycle out of here.
+ */
+export interface LineSelection {
+  id: number;
+  selected: boolean;
+}
+
+export interface RidershipViewInput {
+  /** `null` is the loading state — it yields the empty view. */
+  records: RidershipRecord[] | null;
+  /** Legend and dataset order follow this order. Do not sort inside the module. */
+  lines: readonly LineSelection[];
+  startDate: Date;
+  endDate: Date;
+  dayOfWeek: DayOfWeek;
+  includeAggregate: boolean;
+  /** Defaults to the bundled `transit-events.json`. */
+  events?: readonly TransitEvent[];
+}
+
+export interface RidershipView {
+  /** The shared Month Axis: chronological union of the selected lines' months. */
+  months: string[];
+  /** One dataset per selected line in `lines` order; the Aggregate Series last, if requested. */
+  datasets: ChartDataset<'line', CustomChartData[]>[];
+  /** Records grouped by line, each carrying its Selection Snapshot. */
+  byLine: ConsolidatedRidership;
+  /** Transit Events inside the Event Window that apply to the selection, chronologically. */
+  events: TransitEvent[];
+}
+
+/**
+ * Derive everything on screen that follows from one set of user choices: the
+ * Month Axis, the per-line series, the Aggregate Series, the per-line record
+ * groups and the context-log events.
+ *
+ * ## The Month Window is deliberately offset
+ *
+ * A record at calendar-month ordinal `R` is included when `S <= R <= E - 2`: the
+ * start month is included, and **the end month and the month immediately before
+ * it are excluded**. This is intended, not an off-by-one bug — the app has always
+ * behaved this way, users have shared URLs against it, and
+ * `e2e/chart-content.spec.ts` renders windows through it into committed PNG
+ * baselines. The `Date` arithmetic below is copied verbatim rather than restated
+ * as an ordinal comparison, precisely so it cannot drift. See
+ * `docs/adr/0001-ridership-month-window-is-deliberately-offset.md`.
+ *
+ * The Event Window, applied further down, is **inclusive on both ends** and
+ * correctly 1-based. The two windows genuinely disagree; that is preserved
+ * rather than reconciled, because reconciling them would change which events
+ * appear for a given URL.
+ */
+export function buildRidershipView(input: RidershipViewInput): RidershipView {
+  const { records, lines, startDate, endDate, dayOfWeek, includeAggregate } =
+    input;
+
+  const consolidatedRidership: ConsolidatedRidership = {};
+
+  /**
+   * Group raw records by line ID, skipping any outside the selected date window.
+   * new Date(year, month) treats month as 0-based, but the data stores it as
+   * 1-based, so the comparison is effectively off by one month —
+   * preserved from the original implementation.
+   */
+  if (records) {
+    for (const record of records) {
+      const metricDate = new Date(record.year, record.month);
+      if (
+        startDate.getTime() >= metricDate.getTime() ||
+        endDate.getTime() <= metricDate.getTime()
+      )
+        continue;
+
+      if (!consolidatedRidership[record.line_name]?.ridershipRecords) {
+        /**
+         * Snapshot selected status on first encounter for this line so the
+         * dataset loop below doesn't need to search lines[] on every record.
+         */
+        consolidatedRidership[record.line_name] = {
+          selected: !!lines.find((l) => l.id === Number(record.line_name))
+            ?.selected,
+          ridershipRecords: [],
+        };
+      }
+      consolidatedRidership[record.line_name].ridershipRecords.push(record);
+    }
+  }
+
+  /**
+   * Collect the selected lines in lines[] order (already alphabetically sorted)
+   * rather than consolidatedRidership order, so the legend ordering is stable
+   * regardless of the numeric key enumeration order of the object.
+   *
+   * Note this filters on the Selection Snapshot, not on `line.selected`: a line
+   * the user has selected but which has no records inside the Month Window is
+   * absent from `consolidatedRidership` entirely, so it produces no dataset.
+   * The event filter below deliberately does the opposite — see there.
+   */
+  const selected = lines.filter(
+    (line) => consolidatedRidership[line.id]?.selected,
+  );
+
+  /**
+   * One shared x-axis for every dataset: the chronologically sorted union of the
+   * months the selected lines cover. Selected lines can cover different spans (a
+   * line added mid-window has far fewer months), and Chart.js appends any label
+   * missing from `labels` to the end of the axis — so deriving the axis from one
+   * dataset scrambles the ordering of the rest.
+   */
+  const months = buildMonthAxis(
+    selected.map((line) => consolidatedRidership[line.id].ridershipRecords),
+  );
+
+  const datasets: ChartDataset<'line', CustomChartData[]>[] = selected.map(
+    (line) => ({
+      data: alignToMonthAxis(
+        consolidatedRidership[line.id].ridershipRecords,
+        months,
+        dayOfWeek,
+      ),
+      label: getLineNames(line.id).current,
+      backgroundColor: getLineColor(line.id),
+      borderColor: getLineColor(line.id),
+    }),
+  );
+
+  /**
+   * Sum every selected line's stat at each month into a single series.
+   */
+  if (includeAggregate) {
+    datasets.push({
+      data: buildAggregateSeries(
+        datasets.map((dataset) => dataset.data),
+        months,
+      ),
+      label: 'Aggregate',
+      backgroundColor: getLineColor(-1),
+      borderColor: getLineColor(-2),
+    });
+  }
+
+  const allEvents = input.events ?? (transitEventsData as TransitEvent[]);
+
+  /**
+   * The Event Window: inclusive on both ends and 1-based, unlike the Month
+   * Window above. Preserve the disagreement.
+   *
+   * The selection set here reads the **live** selection (`lines.filter(l =>
+   * l.selected)`), not the Selection Snapshot the datasets filter on. That is
+   * not an oversight: an event on a selected line that has no records inside the
+   * Month Window still shows in the context log.
+   *
+   * None of this depends on `records`, so events are still filtered and returned
+   * while the ridership data is loading — matching the app's behaviour today.
+   */
+  const selectedLineIds = new Set(
+    lines.filter((l) => l.selected).map((l) => l.id),
+  );
+  const startYYYYMM = startDate.getFullYear() * 100 + (startDate.getMonth() + 1);
+  const endYYYYMM = endDate.getFullYear() * 100 + (endDate.getMonth() + 1);
+
+  const events = allEvents
+    .filter((event) => {
+      const [year, month] = event.date.split('-').map(Number);
+      const eventYYYYMM = year * 100 + month;
+      if (eventYYYYMM < startYYYYMM || eventYYYYMM > endYYYYMM) return false;
+      if (event.line_ids.length === 0) return true;
+      return event.line_ids.some((id) => selectedLineIds.has(id));
+    })
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return {
+    months,
+    datasets,
+    byLine: consolidatedRidership,
+    events,
+  };
+}

--- a/src/ridership/index.ts
+++ b/src/ridership/index.ts
@@ -4,10 +4,18 @@
  * Everything else in this folder is implementation: importing `../ridership/chartData`
  * from outside is visibly reaching past the seam. See
  * `docs/adr/0003-one-domain-folder-not-a-repo-wide-reorganisation.md`.
- *
- * Transitional shape — these three helpers are re-exported only so the move of
- * `chartData` stays a pure relocation. They are replaced by the single
- * `buildRidershipView` export once that module exists (#102).
+ */
+export {
+  buildRidershipView,
+  type RidershipView,
+  type RidershipViewInput,
+  type LineSelection,
+} from './buildRidershipView';
+
+/**
+ * Transitional — `App.tsx` still calls the chart helpers directly. Dropped in
+ * #103, once App is wired to `buildRidershipView` and `chartData` becomes
+ * implementation reachable only from within this folder.
  */
 export {
   buildMonthAxis,


### PR DESCRIPTION
Closes #102. **PR 2 of 3** for #100. Stacked on #106 — review that first.

Purely additive. **`src/App.tsx` is not touched**, so the module is green but unused at the end of this PR. That is the point: any red here means the *new module* is wrong, a signal worth isolating from the wiring PR that follows.

## The module

`buildRidershipView` is the ridership derivation's entire public surface. It takes the records, the line selection, the window, the day-of-week and whether to aggregate; it returns the Month Axis, the datasets, the Consolidated Ridership and the filtered Transit Events.

The body is `App.tsx`'s two memos lifted **verbatim**. The `Date` arithmetic of the Month Window is copied exactly rather than restated as an ordinal comparison ([ADR-0001](https://github.com/streetsforall/metro_ridership_app/blob/main/docs/adr/0001-ridership-month-window-is-deliberately-offset.md)) — copy-paste is provably non-drifting, algebra is only provably equivalent if the algebra is right. The doc comment now spells the rule out: a record at calendar-month ordinal `R` is included when `S ≤ R ≤ E − 2`.

`lines` is narrowed to `{ id, selected }` so the module structurally cannot start reading the derived metrics written back onto `Line`. `Line` satisfies it, so #103 passes `lines` unchanged.

The view returns Chart.js dataset types — [ADR-0002](https://github.com/streetsforall/metro_ridership_app/blob/main/docs/adr/0002-ridership-view-returns-chart-js-dataset-types.md). `import type` is erased at build; no runtime coupling, no bundle weight.

## Two things that look like bugs and are not

Both are now commented in place, next to each other:

- **The datasets filter on the Selection Snapshot** (`byLine[line.id]?.selected`), so a selected line with no records in the Month Window produces no dataset.
- **The event filter reads the live selection** (`lines.filter(l => l.selected)`), so an event on that *same* line still shows in the context log.

Likewise, when `records` is `null` (loading), `months` / `datasets` / `byLine` are empty but **events are still filtered and returned** — today's events memo has no `ridershipRecords` dependency, and that is preserved.

## The tests

37 new tests. Beyond the 13 assertions migrating out of `App.test.tsx` in #103:

- **The Month Window boundary table** ADR-0001 depends on — with `start = 2022-01`, `end = 2024-01`: `2021-12` out, `2022-01` **in**, `2023-11` (`E−2`) **in**, `2023-12` (`E−1`) out, `2024-01` (`E`) out. These tests, not the arithmetic, are what makes a future `Month` module safe.
- **The transit-event filter, which had zero coverage** — `App.test.tsx` mocks `OutputArea` and discards the `transitEvents` prop. Window bounds, system-wide events, selection intersection, sort order, and the live-selection quirk above.
- The Event Window's **inclusive** bounds are asserted in the same file as the Month Window's **exclusive** ones, on the same dates, so the divergence is visible rather than folklore: at `end = 2024-01`, an event at `2024-01` is in while a record at `2024-01` is out.
- The empty view, both halves.

Fixtures are local to the file — consolidating the suite's duplicated factories is #104, deliberately separate so these diffs stay skimmable for drift.

## Verification

```
npm run lint   ✓
npm run test   ✓ 18 files, 403 tests (366 → 403, all 37 new)
npm run build  ✓
git diff --stat HEAD -- src/App.tsx   ✓ empty
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)