### PR TITLE
refactor(app): wire App to buildRidershipView

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor, act } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import App from './App';
 import type { ChartDataset } from 'chart.js';
 import type { CustomChartData } from './@types/chart.types';
@@ -39,20 +39,16 @@ const RIDERSHIP_COLUMNAR = {
 };
 
 let capturedDatasets: ChartDataset<'line', CustomChartData[]>[] = [];
-let capturedMonths: string[] = [];
 
 vi.mock('./components/OutputArea', () => ({
   default: ({
     chartDatasets,
-    months,
     showContextLogs,
   }: {
     chartDatasets: ChartDataset<'line', CustomChartData[]>[];
-    months: string[];
     showContextLogs: boolean;
   }) => {
     capturedDatasets = chartDatasets;
-    capturedMonths = months;
     return (
       <div data-testid="output-area">
         {showContextLogs && <div data-testid="context-log-panel" />}
@@ -68,7 +64,6 @@ vi.mock('./components/LineSelector', () => ({ default: () => <div /> }));
 
 beforeEach(() => {
   capturedDatasets = [];
-  capturedMonths = [];
   window.history.replaceState({}, '', '/');
   vi.stubGlobal(
     'fetch',
@@ -109,77 +104,14 @@ describe('App chart dataset ordering', () => {
   });
 });
 
-describe('App - line selection', () => {
-  it('produces empty datasets when no lines are selected', async () => {
-    render(<App />);
-    // Flush all effects; no lines selected so datasets should remain empty
-    await act(async () => {});
-    expect(capturedDatasets).toHaveLength(0);
-  });
+// The derivation rules these used to assert — line selection, day-of-week field
+// choice, the month window's boundaries, aggregate ordering and the shared month
+// axis — now live in src/ridership/buildRidershipView.test.ts, where they are
+// reachable without rendering App. What stays here is wiring: one test per URL
+// param that has to reach the module, plus the fetch path.
 
-  it('produces one dataset for a single selected line', async () => {
-    window.history.replaceState({}, '', '?lines=807');
-
-    render(<App />);
-
-    await waitForDatasets(1);
-
-    expect(capturedDatasets).toHaveLength(1);
-    expect(capturedDatasets[0].label).toBe('K Line');
-  });
-
-  it('produces one dataset per selected line', async () => {
-    window.history.replaceState({}, '', '?lines=806,807');
-
-    render(<App />);
-
-    await waitForDatasets(2);
-
-    const labels = capturedDatasets.map((ds) => ds.label);
-    expect(labels).toContain('K Line');
-    expect(labels).toContain('L Line');
-  });
-
-  it('assigns the correct brand color to each line', async () => {
-    window.history.replaceState({}, '', '?lines=806,807');
-
-    render(<App />);
-
-    await waitForDatasets(2);
-
-    const kLine = capturedDatasets.find((ds) => ds.label === 'K Line');
-    const lLine = capturedDatasets.find((ds) => ds.label === 'L Line');
-
-    expect(kLine?.borderColor).toBe('#e56db1'); // K Line pink
-    expect(lLine?.borderColor).toBe('#f9a825'); // L Line gold
-  });
-});
-
-describe('App - day of week', () => {
-  it('uses weekday ridership by default', async () => {
-    window.history.replaceState({}, '', '?lines=807');
-
-    render(<App />);
-
-    await waitForDatasets(1);
-
-    // K Line 2022-01: est_wkday_ridership = 5000
-    const kLine = capturedDatasets.find((ds) => ds.label === 'K Line');
-    expect(kLine?.data[0].stat).toBe(5000);
-  });
-
-  it('uses weekday ridership when day=wkday', async () => {
-    window.history.replaceState({}, '', '?lines=807&day=wkday');
-
-    render(<App />);
-
-    await waitForDatasets(1);
-
-    const kLine = capturedDatasets.find((ds) => ds.label === 'K Line');
-    expect(kLine?.data[0].stat).toBe(5000);
-  });
-
-  it('uses Saturday ridership when day=sat', async () => {
+describe('App - day of week wiring', () => {
+  it('threads the day param through the hook into the module', async () => {
     window.history.replaceState({}, '', '?lines=807&day=sat');
 
     render(<App />);
@@ -190,200 +122,37 @@ describe('App - day of week', () => {
     const kLine = capturedDatasets.find((ds) => ds.label === 'K Line');
     expect(kLine?.data[0].stat).toBe(3000);
   });
-
-  it('uses Sunday ridership when day=sun', async () => {
-    window.history.replaceState({}, '', '?lines=807&day=sun');
-
-    render(<App />);
-
-    await waitForDatasets(1);
-
-    // K Line 2022-01: est_sun_ridership = 2000
-    const kLine = capturedDatasets.find((ds) => ds.label === 'K Line');
-    expect(kLine?.data[0].stat).toBe(2000);
-  });
 });
 
-describe('App - date range filtering', () => {
-  it('excludes records before the start date', async () => {
-    // start=2021-01 → Jan 2021; the 2019-01 K Line record is before this.
-    // Pin the end so the assertion isolates start filtering (the default end
-    // now tracks the latest data and would otherwise include 2026-01).
+describe('App - date range wiring', () => {
+  it('threads the start and end params through the hook into the module', async () => {
+    // start=2021-01 excludes the 2019-01 K Line record; end=2024-01 excludes the
+    // 2026-01 one. The end is pinned explicitly — vitest resolves
+    // virtual:ridership-bounds from the real dataset, so the default end tracks
+    // live data and would otherwise move this assertion.
     window.history.replaceState({}, '', '?lines=807&start=2021-01&end=2024-01');
 
     render(<App />);
 
     await waitForDatasets(1);
 
-    // Only 2022-01 survives: 2019-01 before start, 2026-01 after end
     const kLine = capturedDatasets.find((ds) => ds.label === 'K Line');
     expect(kLine?.data).toHaveLength(1);
     expect(kLine?.data[0].stat).toBe(5000);
   });
-
-  it('excludes records after the end date', async () => {
-    // end=2024-01 → Jan 2024; the 2026-01 K Line record is after this
-    window.history.replaceState({}, '', '?lines=807&end=2024-01');
-
-    render(<App />);
-
-    await waitForDatasets(1);
-
-    // Only 2022-01 survives: 2019-01 before default start, 2026-01 after end
-    const kLine = capturedDatasets.find((ds) => ds.label === 'K Line');
-    expect(kLine?.data).toHaveLength(1);
-  });
-
-  it('includes all K Line records when the range is wide enough', async () => {
-    // start=2018-01, end=2027-01 covers all three K Line records
-    window.history.replaceState({}, '', '?lines=807&start=2018-01&end=2027-01');
-
-    render(<App />);
-
-    await waitForDatasets(1);
-
-    const kLine = capturedDatasets.find((ds) => ds.label === 'K Line');
-    expect(kLine?.data).toHaveLength(3);
-  });
-
-  it('produces no dataset for a line with no records in range', async () => {
-    // Narrow range that excludes all K Line records: 2023-06 → 2024-06
-    window.history.replaceState({}, '', '?lines=807&start=2023-06&end=2024-06');
-
-    render(<App />);
-
-    await act(async () => {});
-
-    expect(capturedDatasets).toHaveLength(0);
-  });
 });
 
-describe('App - aggregate dataset', () => {
-  it('does not include Aggregate dataset when aggregate param is absent', async () => {
-    window.history.replaceState({}, '', '?lines=806,807');
-
-    render(<App />);
-
-    await waitForDatasets(2);
-
-    const labels = capturedDatasets.map((ds) => ds.label);
-    expect(labels).not.toContain('Aggregate');
-  });
-
-  it('adds Aggregate dataset when aggregate=1', async () => {
+describe('App - aggregate wiring', () => {
+  it('threads aggregate=1 through the hook into the module', async () => {
     window.history.replaceState({}, '', '?lines=806,807&aggregate=1');
 
+    // 2 lines + 1 aggregate = 3
     render(<App />);
 
-    // 2 lines + 1 aggregate = 3
     await waitForDatasets(3);
 
     const labels = capturedDatasets.map((ds) => ds.label);
     expect(labels).toContain('Aggregate');
-  });
-
-  it('Aggregate stat equals the sum of selected line stats at each time point', async () => {
-    window.history.replaceState({}, '', '?lines=806,807&aggregate=1');
-
-    render(<App />);
-
-    await waitForDatasets(3);
-
-    const kLine = capturedDatasets.find((ds) => ds.label === 'K Line');
-    const lLine = capturedDatasets.find((ds) => ds.label === 'L Line');
-    const aggregate = capturedDatasets.find((ds) => ds.label === 'Aggregate');
-
-    expect(kLine).toBeDefined();
-    expect(lLine).toBeDefined();
-    expect(aggregate).toBeDefined();
-
-    // 2022-01: K weekday = 5000, L weekday = 8000 → aggregate = 13000
-    expect(aggregate!.data[0].stat).toBe(
-      kLine!.data[0].stat! + lLine!.data[0].stat!,
-    );
-    expect(aggregate!.data[0].stat).toBe(13000);
-  });
-
-  it('Aggregate is last in the datasets array', async () => {
-    window.history.replaceState({}, '', '?lines=806,807&aggregate=1');
-
-    render(<App />);
-
-    await waitForDatasets(3);
-
-    const lastLabel = capturedDatasets[capturedDatasets.length - 1].label;
-    expect(lastLabel).toBe('Aggregate');
-  });
-});
-
-describe('App - shared month axis across lines of differing coverage', () => {
-  // Regression: the axis used to be taken from chartDatasets[0] alone. D Line sorts
-  // first and covers far fewer months than E Line, so the axis became D Line's months
-  // and Chart.js appended E Line's remaining months to the *end* — producing an
-  // x-axis that jumped from 2026 back to 2020 and a stroke drawn across the plot.
-  const bothRailLines = '?lines=804,805&start=2020-01&end=2027-01';
-
-  it('spans the union of both lines months in chronological order', async () => {
-    window.history.replaceState({}, '', bothRailLines);
-
-    render(<App />);
-
-    await waitForDatasets(2);
-
-    expect(capturedMonths).toEqual(['2020 8', '2022 1', '2025 7', '2026 1']);
-  });
-
-  it('gives every dataset the same time sequence as the axis', async () => {
-    window.history.replaceState({}, '', bothRailLines);
-
-    render(<App />);
-
-    await waitForDatasets(2);
-
-    for (const dataset of capturedDatasets)
-      expect(dataset.data.map((d) => d.time)).toEqual(capturedMonths);
-  });
-
-  it('nulls the months the short line does not cover', async () => {
-    window.history.replaceState({}, '', bothRailLines);
-
-    render(<App />);
-
-    await waitForDatasets(2);
-
-    const dLine = capturedDatasets.find((ds) => ds.label === 'D Line');
-    // D Line reports only 2025-07 and 2026-01; the earlier months are gaps, not
-    // points shifted onto the front of the axis.
-    expect(dLine?.data.map((d) => d.stat)).toEqual([null, null, 700, 900]);
-  });
-
-  it('keeps the long line aligned to its own months', async () => {
-    window.history.replaceState({}, '', bothRailLines);
-
-    render(<App />);
-
-    await waitForDatasets(2);
-
-    const eLine = capturedDatasets.find((ds) => ds.label === 'E Line');
-    expect(eLine?.data.map((d) => d.stat)).toEqual([4000, 4400, 4800, 5200]);
-  });
-
-  it('sums the aggregate by month rather than by array index', async () => {
-    window.history.replaceState({}, '', `${bothRailLines}&aggregate=1`);
-
-    render(<App />);
-
-    await waitForDatasets(3);
-
-    const aggregate = capturedDatasets.find((ds) => ds.label === 'Aggregate');
-    // Months only E Line reports total E Line alone — a line with no record must
-    // not be counted as a zero and drag the total down.
-    expect(aggregate?.data.map((d) => d.stat)).toEqual([
-      4000,
-      4400,
-      4800 + 700,
-      5200 + 900,
-    ]);
   });
 });
 
@@ -409,29 +178,18 @@ describe('App - context log panel', () => {
   });
 });
 
-describe('App - chart data format', () => {
-  it('formats each data point time as "year month"', async () => {
+describe('App - ridership fetch', () => {
+  it('renders with no datasets until the columnar fetch resolves into the module', async () => {
     window.history.replaceState({}, '', '?lines=807');
 
     render(<App />);
 
-    await waitForDatasets(1);
-
-    const kLine = capturedDatasets.find((ds) => ds.label === 'K Line');
-    // Record year=2022, month=1 → createTimeStringForChartData returns "2022 1"
-    expect(kLine?.data[0].time).toBe('2022 1');
-  });
-
-  it('data points include both time and stat fields', async () => {
-    window.history.replaceState({}, '', '?lines=807');
-
-    render(<App />);
+    // Before the fetch settles there are no records, so the module yields the
+    // empty view; afterwards the decoded records reach it.
+    expect(capturedDatasets).toHaveLength(0);
 
     await waitForDatasets(1);
 
-    const kLine = capturedDatasets.find((ds) => ds.label === 'K Line');
-    const point = kLine?.data[0];
-    expect(point).toHaveProperty('time');
-    expect(point).toHaveProperty('stat');
+    expect(capturedDatasets[0].label).toBe('K Line');
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo, lazy, Suspense } from 'react';
-import { type ChartDataset } from 'chart.js';
 import DateRangeSelector from './components/DateRangeSelector';
 import Footer from './components/Footer';
 import Header from './components/Header';
@@ -7,20 +6,9 @@ import LineSelector from './components/LineSelector';
 import useUserDashboardInput, {
   type UserDashboardInputState,
 } from './hooks/useUserDashboardInput';
-import {
-  alignToMonthAxis,
-  buildAggregateSeries,
-  buildMonthAxis,
-} from './ridership';
-import { getLineColor, getLineNames } from './utils/lines';
+import { buildRidershipView } from './ridership';
 import { decodeRidership, type ColumnarRidership } from './utils/ridershipData';
-import type { CustomChartData } from './@types/chart.types';
-import type {
-  ConsolidatedRidership,
-  RidershipRecord,
-} from './@types/metrics.types';
-import transitEventsData from './data/transit-events.json';
-import type { TransitEvent } from './@types/events.types';
+import type { RidershipRecord } from './@types/metrics.types';
 
 /**
  * OutputArea pulls in Chart.js and MapLibre GL. Lazy-loading it keeps MapLibre (the
@@ -76,124 +64,36 @@ function App() {
   const isLoading = ridershipRecords === null;
 
   /**
-   * Computes chartDatasets, monthList and ridershipByLine together in a single pass
-   * over ridershipRecords since all three are derived from the same filtered view of
-   * the data. Until the data loads (`ridershipRecords` is null) this yields empty
-   * results.
+   * The whole derived view — month axis, per-line datasets, records grouped by
+   * line, and the context-log events — in one pass. Every rule in it (the
+   * deliberately offset month window, the shared axis, the aggregate ordering)
+   * lives in src/ridership/ and is unit-tested there.
+   *
+   * Kept memoised: the metrics effect below keys on JSON.stringify(byLine), and
+   * a fresh object every render would thrash it.
    */
-  const { chartDatasets, monthList, ridershipByLine } = useMemo(() => {
-    const consolidatedRidership: ConsolidatedRidership = {};
-
-    /**
-     * Group raw records by line ID, skipping any outside the selected date window.
-     * new Date(year, month) treats month as 0-based, but the data stores it as
-     * 1-based, so the comparison is effectively off by one month —
-     * preserved from the original implementation.
-     */
-    if (ridershipRecords) {
-      for (const record of ridershipRecords) {
-        const metricDate = new Date(record.year, record.month);
-        if (
-          startDate.getTime() >= metricDate.getTime() ||
-          endDate.getTime() <= metricDate.getTime()
-        )
-          continue;
-
-        if (!consolidatedRidership[record.line_name]?.ridershipRecords) {
-          /**
-           * Snapshot selected status on first encounter for this line so the
-           * dataset loop below doesn't need to search lines[] on every record.
-           */
-          consolidatedRidership[record.line_name] = {
-            selected: !!lines.find((l) => l.id === Number(record.line_name))
-              ?.selected,
-            ridershipRecords: [],
-          };
-        }
-        consolidatedRidership[record.line_name].ridershipRecords.push(record);
-      }
-    }
-
-    /**
-     * Collect the selected lines in lines[] order (already alphabetically sorted)
-     * rather than consolidatedRidership order, so the legend ordering is stable
-     * regardless of the numeric key enumeration order of the object.
-     */
-    const selected = lines.filter(
-      (line) => consolidatedRidership[line.id]?.selected,
-    );
-
-    /**
-     * One shared x-axis for every dataset: the chronologically sorted union of the
-     * months the selected lines cover. Selected lines can cover different spans (a
-     * line added mid-window has far fewer months), and Chart.js appends any label
-     * missing from `labels` to the end of the axis — so deriving the axis from one
-     * dataset scrambles the ordering of the rest.
-     */
-    const months = buildMonthAxis(
-      selected.map((line) => consolidatedRidership[line.id].ridershipRecords),
-    );
-
-    const datasets: ChartDataset<'line', CustomChartData[]>[] = selected.map(
-      (line) => ({
-        data: alignToMonthAxis(
-          consolidatedRidership[line.id].ridershipRecords,
-          months,
-          dayOfWeek,
-        ),
-        label: getLineNames(line.id).current,
-        backgroundColor: getLineColor(line.id),
-        borderColor: getLineColor(line.id),
+  const { months, datasets, byLine, events } = useMemo(
+    () =>
+      buildRidershipView({
+        records: ridershipRecords,
+        lines,
+        startDate,
+        endDate,
+        dayOfWeek,
+        includeAggregate: isAggregateVisible,
       }),
-    );
-
-    /**
-     * Sum every selected line's stat at each month into a single series.
-     */
-    if (isAggregateVisible) {
-      datasets.push({
-        data: buildAggregateSeries(
-          datasets.map((dataset) => dataset.data),
-          months,
-        ),
-        label: 'Aggregate',
-        backgroundColor: getLineColor(-1),
-        borderColor: getLineColor(-2),
-      });
-    }
-
-    return {
-      chartDatasets: datasets,
-      monthList: months,
-      ridershipByLine: consolidatedRidership,
-    };
-  }, [startDate, endDate, lines, dayOfWeek, isAggregateVisible, ridershipRecords]);
-
-  const transitEvents = useMemo(() => {
-    const selectedLineIds = new Set(lines.filter((l) => l.selected).map((l) => l.id));
-    const startYYYYMM = startDate.getFullYear() * 100 + (startDate.getMonth() + 1);
-    const endYYYYMM = endDate.getFullYear() * 100 + (endDate.getMonth() + 1);
-
-    return (transitEventsData as TransitEvent[])
-      .filter((event) => {
-        const [year, month] = event.date.split('-').map(Number);
-        const eventYYYYMM = year * 100 + month;
-        if (eventYYYYMM < startYYYYMM || eventYYYYMM > endYYYYMM) return false;
-        if (event.line_ids.length === 0) return true;
-        return event.line_ids.some((id) => selectedLineIds.has(id));
-      })
-      .sort((a, b) => a.date.localeCompare(b.date));
-  }, [startDate, endDate, lines]);
+    [ridershipRecords, lines, startDate, endDate, dayOfWeek, isAggregateVisible],
+  );
 
   /**
    * Attach computed metrics (average ridership, change, etc.) to each line entry
    * so the LineSelector can display them. JSON.stringify is used as the dependency
-   * because ridershipByLine is a new object reference on every render (useMemo).
+   * because byLine is a new object reference on every render (useMemo).
    */
   useEffect(() => {
-    updateLinesWithLineMetrics(ridershipByLine);
+    updateLinesWithLineMetrics(byLine);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(ridershipByLine)]);
+  }, [JSON.stringify(byLine)]);
 
   return (
     /* Stretch full height */
@@ -226,7 +126,7 @@ function App() {
           <LineSelector
             {...userDashboardInputState}
             lines={visibleLines}
-            ridershipByLine={ridershipByLine}
+            ridershipByLine={byLine}
             isExpanded={isLineSelectorExpanded}
             setIsExpanded={setIsLineSelectorExpanded}
           />
@@ -247,10 +147,10 @@ function App() {
             }
           >
             <OutputArea
-              chartDatasets={chartDatasets}
-              months={monthList}
+              chartDatasets={datasets}
+              months={months}
               lines={lines}
-              transitEvents={transitEvents}
+              transitEvents={events}
               showContextLogs={showContextLogs}
               isLoading={isLoading}
             />

--- a/src/ridership/index.ts
+++ b/src/ridership/index.ts
@@ -11,14 +11,3 @@ export {
   type RidershipViewInput,
   type LineSelection,
 } from './buildRidershipView';
-
-/**
- * Transitional — `App.tsx` still calls the chart helpers directly. Dropped in
- * #103, once App is wired to `buildRidershipView` and `chartData` becomes
- * implementation reachable only from within this folder.
- */
-export {
-  buildMonthAxis,
-  alignToMonthAxis,
-  buildAggregateSeries,
-} from './chartData';


### PR DESCRIPTION
Closes #103. **PR 3 of 3** for #100. Stacked on #107 — review that first.

**Nothing new is introduced here.** The diff is `App.tsx` shrinking and `App.test.tsx` losing the 13 assertions that now live in `src/ridership/buildRidershipView.test.ts`. That means **any red in this PR is behaviour drift**, which is the entire reason it is not folded into #107.

```
 src/App.test.tsx       | 288 ++++--------------------------
 src/App.tsx            | 154 +++++---------------
 src/ridership/index.ts |  11 --
 3 files changed, 50 insertions(+), 403 deletions(-)
```

## What changed

- **Both memos collapse into one `buildRidershipView` call.** The `useMemo` stays — the metrics effect keys on `JSON.stringify(byLine)` and would thrash without it — and the dependency array stays raw `lines`, which is a state value with a stable reference between renders.
- **Renames are at the call sites only**: `chartDatasets` → `datasets`, `monthList` → `months`, `ridershipByLine` → `byLine`, `transitEvents` → `events`. The `OutputArea` and `LineSelector` **prop names are unchanged**.
- `isLoading` stays `ridershipRecords === null` in `App.tsx` — it is a fetch concern.
- `updateLinesWithLineMetrics(byLine)` and its `JSON.stringify` dependency are **untouched**. Unwinding that write-back loop is candidate 2 of the architecture review, not this work.
- `src/ridership/index.ts` drops the transitional chart-helper exports. `chartData` is now implementation: reachable within the folder, not from outside it.

## `App.test.tsx`: 20 tests → 7

Principle: App keeps one wiring test per URL param that feeds the module, plus the fetch path. Everything asserting a derivation rule has moved.

| Block | Was | Now |
| --- | --- | --- |
| dataset ordering (K before L) | 1 | **1 — kept as-is**, the #86 regression deserves an end-to-end pin |
| line selection | 4 | 0 — moved |
| day of week | 4 | **1** — `?lines=807&day=sat` → 3000 |
| date range filtering | 4 | **1** — `?lines=807&start=2021-01&end=2024-01` → one point |
| aggregate dataset | 5 | **1** — `aggregate=1` → an `Aggregate` dataset exists |
| shared month axis | 5 | 0 — moved; `e2e/chart-content.spec.ts` pins the rendered result |
| context log panel | 2 | **2 — kept**, `showContextLogs` prop threading |
| chart data format | 2 | 0 — moved |
| ridership fetch | 0 | **1** — empty view before the columnar fetch resolves, K Line after |

Every deleted assertion was confirmed to have an equivalent in `buildRidershipView.test.ts` first. `end=` stays pinned in the surviving date-range test — vitest resolves `virtual:ridership-bounds` from the real `src/data/ridership.json`, so the default end tracks live data.

The `OutputArea` mock and the columnar fetch mock are kept; that is how wiring stays observable. `capturedMonths` and the `act` import went with the tests that used them.

## Verification — no baseline was regenerated

```
npm run lint   ✓
npm run test   ✓ 18 files, 384 tests (403 → 384; the 19 deleted App tests, none of them new coverage)
npm run build  ✓
npm run test:e2e   ✓ 20/20
```

The e2e result needs its provenance stated, because only the Linux baselines are committed and `-win32.png` is per-developer scratch that a first local run writes — so a naive local run would have compared this branch against *itself*. What was actually done:

1. Deleted every `*-win32.png`.
2. Checked the working tree out to **`main`'s source** and ran the suite — this wrote the win32 baselines from **main's** render.
3. Re-ran on main's source: **20/20**, confirming main is self-consistent and the baselines are stable.
4. Restored this branch and ran the same suite against **main's** baselines: **20/20**.

(Run 4 first reported 1 failure, `[desktop] line selector — expanded table view`; it passed on re-run and on a second full-suite run, and the mobile variant of the same test passed throughout. Flake, not drift.)

**No committed PNG was touched** — `git status` shows only the three source files above.

The remaining manual spot-checks in the issue are covered by tests rather than eyeballing: the five `chart-content.spec.ts` baselines (single line / multiple lines / aggregate / Saturday / narrow window) all pass unchanged; URL-order independence is pinned by the surviving `App.test.tsx` ordering test plus the pure ordering tests; and the bundled-events default, including the K Line's Regional Connector opening in a 2022-01 → 2024-01 window, is pinned in `buildRidershipView.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)