### PR TITLE
docs: mark letter B done and unblock C, E and G

### DIFF
--- a/docs/architecture-review-2026-08-05.md
+++ b/docs/architecture-review-2026-08-05.md
@@ -25,23 +25,32 @@ opens the PR. Letters run in one series and are never reused. Batch prefix:
 | Letter | Candidate | Session does | Status |
 | --- | --- | --- | --- |
 | A | 1 — ridership view module | grill → spec → tickets | **done** — #100 (+ #101, #102, #103, #104) |
-| B | 1 — ridership view module | implement → PR | **ready** — work #101 → #102 → #103 |
-| C | 2 — derived metrics off state | grill → spec → tickets | blocked by B |
+| B | 1 — ridership view module | implement → PR | **done** — #105, #106, #107, #108 |
+| C | 2 — derived metrics off state | grill → spec → tickets | **ready** |
 | D | 2 — derived metrics off state | implement → PR | blocked by C |
-| E | 3 — collapse `calc.ts` | grill → spec → tickets | blocked by B |
+| E | 3 — collapse `calc.ts` | grill → spec → tickets | **ready** |
 | F | 3 — collapse `calc.ts` | implement → PR | blocked by E |
-| G | 4 — a `Month` module | grill → spec → tickets | blocked by B |
+| G | 4 — a `Month` module | grill → spec → tickets | **ready** |
 | H | 4 — a `Month` module | implement → PR | blocked by G |
 | — | 5 — URL contract · 6 — CSV seam | unscheduled | letters assigned when picked up |
 
-Candidate 1 is the frozen contract: it defines the module that 2, 3 and 4 all attach to, so it
-lands alone before anything else starts.
+Candidate 1 was the frozen contract: it defines the module that 2, 3 and 4 all attach to, so it
+landed alone before anything else started. It is now on `main`, which is what unblocked C, E and
+G — they are independent of each other and can run in any order, or in parallel.
 
-A's outputs are on branch `claude/agitated-nash-d3e284`: `CONTEXT.md` (the repo's first glossary),
-`docs/adr/0001`–`0003`, and `src/plans/ridership-view-module.md`. C, E and G should read those
-before grilling — in particular ADR-0001, which settles the deliberate month-window offset, and
-ADR-0003, which settles why `src/ridership/` is the only domain folder. #104 (duplicated test-data
-factories) came out of A but is independent of the module and of every other letter.
+A's outputs are on `main`: `CONTEXT.md` (the repo's first glossary), `docs/adr/0001`–`0003`, and
+`src/plans/ridership-view-module.md`. C, E and G should read those before grilling — in
+particular ADR-0001, which settles the deliberate month-window offset, and ADR-0003, which
+settles why `src/ridership/` is the only domain folder. #104 (duplicated test-data factories)
+came out of A but is independent of the module and of every other letter.
+
+What B actually landed, since the later letters attach to it: `buildRidershipView` in
+`src/ridership/`, whose entire public surface is that one function; `chartData.ts` demoted to
+implementation inside the folder; `App.tsx` down to markup and wiring; and the month-window
+boundaries plus the transit-event filter under unit test for the first time. Two things B
+deliberately did **not** touch, because they belong to later letters:
+`updateLinesWithLineMetrics` and its `JSON.stringify` dependency are untouched for C, and
+`src/utils/calc.ts` is untouched for E.
 
 ---
 


### PR DESCRIPTION
Docs-only. Candidate 1 landed in #105–#108, so the status table in `docs/architecture-review-2026-08-05.md` is stale in five rows — and that table is what the next sessions read to decide what is startable.

## What changed

| Row | Was | Now |
| --- | --- | --- |
| B | **ready** — work #101 → #102 → #103 | **done** — #105, #106, #107, #108 |
| C | blocked by B | **ready** |
| E | blocked by B | **ready** |
| G | blocked by B | **ready** |

Plus two bits of surrounding prose:

- A's outputs are described as living on branch `claude/agitated-nash-d3e284`. They are on `main` now (#105).
- Added a short note on what B actually landed, and — more useful to the next letter — the two things it *deliberately* left untouched, because those are the seams C and E attach to: `updateLinesWithLineMetrics` and its `JSON.stringify` dependency for C, `src/utils/calc.ts` for E.

C, E and G are independent of each other and can run in any order, or in parallel. D, F and H stay blocked on their own spec halves. #104 is unaffected — it was always independent.

## Deliberately not changed

The per-candidate sections below the table still carry the file paths and line ranges as they were on 2026-08-05 — e.g. candidate 1's `src/utils/chartData.ts`, which is now `src/ridership/chartData.ts`, and candidate 2's `src/App.tsx (L193–196)`, where the metrics effect is now at L94. Those sections are a record of a review taken at a point in time; the table is the living part of the document, and rewriting the analysis to match today's tree would blur that.

Worth a follow-up if the drift starts costing the next sessions time — candidate 2's line range is the one letter C will actually chase.

## Verification

```
npm run lint   ✓
npm run build  ✓
```

No source touched; `npm run test` is unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)