### PR TITLE
test: consolidate the duplicated fixture factories into src/test/builders.ts

### DIFF
--- a/src/components/Map.test.tsx
+++ b/src/components/Map.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, act } from '@testing-library/react';
 import maplibregl from 'maplibre-gl';
 import Map from './Map';
-import type { Line } from '../@types/lines.types';
+import { makeLine } from '../test/builders';
 
 // Hoisted so the vi.mock factory below can close over them
 const captured = vi.hoisted(() => ({
@@ -46,16 +46,6 @@ vi.mock('maplibre-gl', () => ({
     };
   }),
 }));
-
-const makeLine = (overrides: Partial<Line> = {}): Line => ({
-  id: 801,
-  name: 'A Line',
-  mode: 'Rail',
-  provider: 'DO',
-  selected: false,
-  visible: true,
-  ...overrides,
-});
 
 beforeEach(() => {
   captured.loadCallback = undefined;

--- a/src/components/OutputArea.test.tsx
+++ b/src/components/OutputArea.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import OutputArea from './OutputArea';
 import { Chart as ChartJS, type ChartOptions } from 'chart.js';
 import type { Line } from '../@types/lines.types';
+import { makeLine } from '../test/builders';
 import type { TransitEvent } from '../@types/events.types';
 
 let capturedOptions: ChartOptions<'line'> | undefined;
@@ -19,16 +20,6 @@ vi.mock('./Map', () => ({
     <div data-testid="map" data-line-count={String(lines.length)} />
   ),
 }));
-
-const makeLine = (overrides: Partial<Line>): Line => ({
-  id: 801,
-  name: 'A Line',
-  mode: 'Rail',
-  provider: 'DO',
-  selected: false,
-  visible: true,
-  ...overrides,
-});
 
 const emptyProps = {
   chartDatasets: [],

--- a/src/components/SummaryData.test.tsx
+++ b/src/components/SummaryData.test.tsx
@@ -1,17 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import SummaryData from './SummaryData';
-import type { Line } from '../@types/lines.types';
-
-const makeLine = (overrides: Partial<Line>): Line => ({
-  id: 801,
-  name: 'A Line',
-  mode: 'Rail',
-  provider: 'DO',
-  selected: false,
-  visible: true,
-  ...overrides,
-});
+import { makeLine } from '../test/builders';
 
 describe('SummaryData with no selected lines', () => {
   it('renders nothing when the lines array is empty', () => {

--- a/src/hooks/useUserDashboardInput.test.ts
+++ b/src/hooks/useUserDashboardInput.test.ts
@@ -4,6 +4,10 @@ import useUserDashboardInput, { daysOfWeek } from './useUserDashboardInput';
 import { dataDefaultEndDate } from '../utils/dataDateRange';
 import { formatMonthParam } from '../utils/queryParams';
 import type { ConsolidatedRidership } from '../@types/metrics.types';
+import {
+  makeConsolidatedRidership,
+  makeRidershipRecord,
+} from '../test/builders';
 
 // Reset URL and replaceState spy before each test
 beforeEach(() => {
@@ -317,21 +321,22 @@ describe('line initialisation', () => {
 });
 
 describe('updateLinesWithLineMetrics', () => {
-  const makeRidership = (lineId: number, wkday: number): ConsolidatedRidership => ({
-    [lineId]: {
-      selected: true,
-      ridershipRecords: [
-        {
-          year: 2022,
-          month: 1,
+  const makeRidership = (
+    lineId: number,
+    wkday: number,
+  ): ConsolidatedRidership =>
+    makeConsolidatedRidership(
+      lineId,
+      [
+        makeRidershipRecord({
           line_name: lineId,
           est_wkday_ridership: wkday,
           est_sat_ridership: null,
           est_sun_ridership: null,
-        },
+        }),
       ],
-    },
-  });
+      { selected: true },
+    );
 
   it('sets ridersPerMile on a line that has distanceMiles', () => {
     const { result } = renderHook(() => useUserDashboardInput());

--- a/src/ridership/buildRidershipView.test.ts
+++ b/src/ridership/buildRidershipView.test.ts
@@ -1,40 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildRidershipView, type LineSelection } from './buildRidershipView';
 import type { DayOfWeek, RidershipRecord } from '../@types/metrics.types';
-import type { TransitEvent } from '../@types/events.types';
-
-/**
- * Local fixture helpers. Deliberately not shared builders — consolidating the
- * suite's six near-identical factories is #104, kept separate so these diffs stay
- * skimmable for behaviour drift.
- */
-const makeRecord = (
-  year: number,
-  month: number,
-  line_name: number,
-  overrides: Partial<RidershipRecord> = {},
-): RidershipRecord => ({
-  year,
-  month,
-  line_name,
-  est_wkday_ridership: 1000,
-  est_sat_ridership: 600,
-  est_sun_ridership: 400,
-  ...overrides,
-});
-
-const makeEvent = (
-  id: string,
-  date: string,
-  line_ids: number[],
-): TransitEvent => ({
-  id,
-  date,
-  line_ids,
-  title: id,
-  description: id,
-  category: 'service_change',
-});
+import { makeRidershipRecord, makeTransitEvent } from '../test/builders';
 
 /**
  * Same shape as `App.test.tsx`'s fixture, so the assertions migrated from there
@@ -48,52 +15,82 @@ const makeEvent = (
  *                  scramble the x-axis.
  */
 const RECORDS: RidershipRecord[] = [
-  makeRecord(2019, 1, 807, {
+  makeRidershipRecord({
+    year: 2019,
+    month: 1,
+    line_name: 807,
     est_wkday_ridership: 1000,
     est_sat_ridership: 600,
     est_sun_ridership: 400,
   }),
-  makeRecord(2020, 8, 804, {
+  makeRidershipRecord({
+    year: 2020,
+    month: 8,
+    line_name: 804,
     est_wkday_ridership: 4000,
     est_sat_ridership: 2000,
     est_sun_ridership: 1000,
   }),
-  makeRecord(2022, 1, 807, {
+  makeRidershipRecord({
+    year: 2022,
+    month: 1,
+    line_name: 807,
     est_wkday_ridership: 5000,
     est_sat_ridership: 3000,
     est_sun_ridership: 2000,
   }),
-  makeRecord(2022, 1, 806, {
+  makeRidershipRecord({
+    year: 2022,
+    month: 1,
+    line_name: 806,
     est_wkday_ridership: 8000,
     est_sat_ridership: 5000,
     est_sun_ridership: 3000,
   }),
-  makeRecord(2022, 1, 804, {
+  makeRidershipRecord({
+    year: 2022,
+    month: 1,
+    line_name: 804,
     est_wkday_ridership: 4400,
     est_sat_ridership: 2200,
     est_sun_ridership: 1100,
   }),
-  makeRecord(2025, 7, 804, {
+  makeRidershipRecord({
+    year: 2025,
+    month: 7,
+    line_name: 804,
     est_wkday_ridership: 4800,
     est_sat_ridership: 2400,
     est_sun_ridership: 1200,
   }),
-  makeRecord(2025, 7, 805, {
+  makeRidershipRecord({
+    year: 2025,
+    month: 7,
+    line_name: 805,
     est_wkday_ridership: 700,
     est_sat_ridership: 350,
     est_sun_ridership: 175,
   }),
-  makeRecord(2026, 1, 807, {
+  makeRidershipRecord({
+    year: 2026,
+    month: 1,
+    line_name: 807,
     est_wkday_ridership: 9000,
     est_sat_ridership: 7000,
     est_sun_ridership: 5000,
   }),
-  makeRecord(2026, 1, 804, {
+  makeRidershipRecord({
+    year: 2026,
+    month: 1,
+    line_name: 804,
     est_wkday_ridership: 5200,
     est_sat_ridership: 2600,
     est_sun_ridership: 1300,
   }),
-  makeRecord(2026, 1, 805, {
+  makeRidershipRecord({
+    year: 2026,
+    month: 1,
+    line_name: 805,
     est_wkday_ridership: 900,
     est_sat_ridership: 450,
     est_sun_ridership: 225,
@@ -236,7 +233,13 @@ describe('buildRidershipView — the Month Window', () => {
   describe('boundaries (start 2022-01, end 2024-01)', () => {
     const windowed = (year: number, monthOfYear: number) =>
       buildRidershipView({
-        records: [makeRecord(year, monthOfYear, 807)],
+        records: [
+          makeRidershipRecord({
+            year,
+            month: monthOfYear,
+            line_name: 807,
+          }),
+        ],
         lines: [K],
         startDate: month(2022, 1),
         endDate: month(2024, 1),
@@ -397,7 +400,7 @@ describe('buildRidershipView — the Event Window', () => {
   it('includes an event exactly at the start month', () => {
     const { events } = build({
       ...eventWindow,
-      events: [makeEvent('at-start', '2022-01', [807])],
+      events: [makeTransitEvent({ id: 'at-start', date: '2022-01', line_ids: [807] })],
     });
 
     expect(events.map((e) => e.id)).toEqual(['at-start']);
@@ -406,8 +409,12 @@ describe('buildRidershipView — the Event Window', () => {
   it('includes an event exactly at the end month — unlike the Month Window', () => {
     const { events, datasets } = build({
       ...eventWindow,
-      records: [makeRecord(2024, 1, 807)],
-      events: [makeEvent('at-end', '2024-01', [807])],
+      records: [
+        makeRidershipRecord({ year: 2024, month: 1, line_name: 807 }),
+      ],
+      events: [
+        makeTransitEvent({ id: 'at-end', date: '2024-01', line_ids: [807] }),
+      ],
     });
 
     expect(events.map((e) => e.id)).toEqual(['at-end']);
@@ -419,7 +426,7 @@ describe('buildRidershipView — the Event Window', () => {
   it('excludes an event one month before the start', () => {
     const { events } = build({
       ...eventWindow,
-      events: [makeEvent('before', '2021-12', [807])],
+      events: [makeTransitEvent({ id: 'before', date: '2021-12', line_ids: [807] })],
     });
 
     expect(events).toEqual([]);
@@ -428,7 +435,7 @@ describe('buildRidershipView — the Event Window', () => {
   it('excludes an event one month after the end', () => {
     const { events } = build({
       ...eventWindow,
-      events: [makeEvent('after', '2024-02', [807])],
+      events: [makeTransitEvent({ id: 'after', date: '2024-02', line_ids: [807] })],
     });
 
     expect(events).toEqual([]);
@@ -446,7 +453,7 @@ describe('buildRidershipView — event selection filtering', () => {
     const { events } = build({
       ...inWindow,
       lines: [{ id: 807, selected: false }],
-      events: [makeEvent('system-wide', '2022-06', [])],
+      events: [makeTransitEvent({ id: 'system-wide', date: '2022-06', line_ids: [] })],
     });
 
     expect(events.map((e) => e.id)).toEqual(['system-wide']);
@@ -456,8 +463,8 @@ describe('buildRidershipView — event selection filtering', () => {
     const { events } = build({
       ...inWindow,
       events: [
-        makeEvent('mine', '2022-06', [807, 806]),
-        makeEvent('not-mine', '2022-07', [806]),
+        makeTransitEvent({ id: 'mine', date: '2022-06', line_ids: [807, 806] }),
+        makeTransitEvent({ id: 'not-mine', date: '2022-07', line_ids: [806] }),
       ],
     });
 
@@ -468,9 +475,9 @@ describe('buildRidershipView — event selection filtering', () => {
     const { events } = build({
       ...inWindow,
       events: [
-        makeEvent('third', '2023-05', [807]),
-        makeEvent('first', '2022-02', [807]),
-        makeEvent('second', '2022-11', [807]),
+        makeTransitEvent({ id: 'third', date: '2023-05', line_ids: [807] }),
+        makeTransitEvent({ id: 'first', date: '2022-02', line_ids: [807] }),
+        makeTransitEvent({ id: 'second', date: '2022-11', line_ids: [807] }),
       ],
     });
 
@@ -482,8 +489,16 @@ describe('buildRidershipView — event selection filtering', () => {
     // datasets filter on. A line with nothing to draw still gets its events.
     const { datasets, events } = build({
       ...inWindow,
-      records: [makeRecord(2019, 1, 807)],
-      events: [makeEvent('still-shows', '2022-06', [807])],
+      records: [
+        makeRidershipRecord({ year: 2019, month: 1, line_name: 807 }),
+      ],
+      events: [
+        makeTransitEvent({
+          id: 'still-shows',
+          date: '2022-06',
+          line_ids: [807],
+        }),
+      ],
     });
 
     expect(datasets).toHaveLength(0);
@@ -528,8 +543,8 @@ describe('buildRidershipView — the empty view', () => {
       startDate: month(2022, 1),
       endDate: month(2024, 1),
       events: [
-        makeEvent('in-window', '2022-06', [807]),
-        makeEvent('out-of-window', '2030-01', [807]),
+        makeTransitEvent({ id: 'in-window', date: '2022-06', line_ids: [807] }),
+        makeTransitEvent({ id: 'out-of-window', date: '2030-01', line_ids: [807] }),
       ],
     });
 

--- a/src/test/builders.ts
+++ b/src/test/builders.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared fixture builders for the Vitest suite.
+ *
+ * Not a test file: Vitest's include glob is `**\/*.{test,spec}.?(c|m)[jt]s?(x)`,
+ * which `builders.ts` does not match, so the runner will not try to collect it as
+ * a suite. It lives beside `src/test-setup.ts` for the same reason — test-only
+ * scaffolding, never imported by application code.
+ *
+ * Conventions:
+ *
+ * - Every builder takes a single `Partial<T>` of overrides and returns a **fresh,
+ *   unfrozen** object. Freezing was considered and rejected: nothing in the suite
+ *   mutates a fixture, a new object is minted per call so cross-test bleed is
+ *   impossible anyway, and a meaningful guard would need a deep freeze over the
+ *   nested `ridershipRecords` / `line_ids` arrays — more machinery than the
+ *   problem warrants, and a trap for a future test that legitimately mutates.
+ * - `selected` defaults to `false` everywhere. Line Selection is the axis most of
+ *   these tests are actually varying, so it should be visible at the call site
+ *   rather than inherited from a default.
+ */
+import type { Line } from '../@types/lines.types';
+import type {
+  ConsolidatedRecord,
+  ConsolidatedRidership,
+  RidershipRecord,
+} from '../@types/metrics.types';
+import type { TransitEvent } from '../@types/events.types';
+
+/**
+ * A Line. Defaults to the A Line (801) — the shape four of the five factories
+ * this replaced already used. `src/utils/lines.test.ts` was the outlier (a
+ * generic `Line 1` bus); its sort cases override `name`, and `id` wherever the
+ * numeric tiebreak matters, so it reads the same against these defaults.
+ */
+export const makeLine = (overrides: Partial<Line> = {}): Line => ({
+  id: 801,
+  name: 'A Line',
+  mode: 'Rail',
+  provider: 'DO',
+  selected: false,
+  visible: true,
+  ...overrides,
+});
+
+/**
+ * A Ridership Record. The 1000 / 600 / 400 defaults come from
+ * `buildRidershipView.test.ts`, the only site that relied on defaulted ridership
+ * figures; every other call site states its numbers.
+ */
+export const makeRidershipRecord = (
+  overrides: Partial<RidershipRecord> = {},
+): RidershipRecord => ({
+  year: 2022,
+  month: 1,
+  line_name: 801,
+  est_wkday_ridership: 1000,
+  est_sat_ridership: 600,
+  est_sun_ridership: 400,
+  ...overrides,
+});
+
+/**
+ * A single-line Consolidated Ridership map, keyed by line id the way
+ * `App.tsx` groups records. Spread several together for a multi-line fixture.
+ */
+export const makeConsolidatedRidership = (
+  lineName: number,
+  ridershipRecords: RidershipRecord[],
+  overrides: Partial<ConsolidatedRecord> = {},
+): ConsolidatedRidership => ({
+  [lineName]: {
+    selected: false,
+    ridershipRecords,
+    ...overrides,
+  },
+});
+
+/** A Transit Event. `line_ids: []` means system-wide. */
+export const makeTransitEvent = (
+  overrides: Partial<TransitEvent> = {},
+): TransitEvent => ({
+  id: 'event',
+  date: '2022-01',
+  line_ids: [],
+  title: 'Event',
+  description: 'Event',
+  category: 'service_change',
+  ...overrides,
+});

--- a/src/utils/lines.test.ts
+++ b/src/utils/lines.test.ts
@@ -5,18 +5,12 @@ import {
   lineNameSortFunction,
   generateCSV,
 } from './lines';
-import type { Line } from '../@types/lines.types';
 import type { ConsolidatedRidership } from '../@types/metrics.types';
-
-const makeLine = (overrides: Partial<Line>): Line => ({
-  id: 1,
-  name: 'Line 1',
-  mode: 'Bus',
-  provider: 'DO',
-  selected: false,
-  visible: true,
-  ...overrides,
-});
+import {
+  makeConsolidatedRidership,
+  makeLine,
+  makeRidershipRecord,
+} from '../test/builders';
 
 describe('getLineColor', () => {
   it('returns the defined color for the A Line (801)', () => {
@@ -143,21 +137,17 @@ describe('generateCSV', () => {
   });
 
   it('includes rows for selected lines', () => {
-    const ridership: ConsolidatedRidership = {
-      '801': {
-        selected: true,
-        ridershipRecords: [
-          {
-            year: 2022,
-            month: 1,
-            line_name: 801,
-            est_wkday_ridership: 5000,
-            est_sat_ridership: 3000,
-            est_sun_ridership: 2000,
-          },
-        ],
-      },
-    };
+    const ridership: ConsolidatedRidership = makeConsolidatedRidership(
+      801,
+      [
+        makeRidershipRecord({
+          est_wkday_ridership: 5000,
+          est_sat_ridership: 3000,
+          est_sun_ridership: 2000,
+        }),
+      ],
+      { selected: true },
+    );
     const csv = decodeURI(generateCSV(ridership));
     expect(csv).toContain('A Line');
     expect(csv).toContain('2022');
@@ -165,70 +155,56 @@ describe('generateCSV', () => {
   });
 
   it('excludes rows for unselected lines', () => {
-    const ridership: ConsolidatedRidership = {
-      '801': {
-        selected: false,
-        ridershipRecords: [
-          {
-            year: 2022,
-            month: 1,
-            line_name: 801,
-            est_wkday_ridership: 5000,
-            est_sat_ridership: 3000,
-            est_sun_ridership: 2000,
-          },
-        ],
-      },
-    };
+    const ridership: ConsolidatedRidership = makeConsolidatedRidership(801, [
+      makeRidershipRecord({
+        est_wkday_ridership: 5000,
+        est_sat_ridership: 3000,
+        est_sun_ridership: 2000,
+      }),
+    ]);
     const csv = decodeURI(generateCSV(ridership));
     expect(csv).not.toContain('5000');
   });
 
   it('uses the friendly line name in the CSV row', () => {
-    const ridership: ConsolidatedRidership = {
-      '802': {
-        selected: true,
-        ridershipRecords: [
-          {
-            year: 2023,
-            month: 6,
-            line_name: 802,
-            est_wkday_ridership: 12000,
-            est_sat_ridership: 8000,
-            est_sun_ridership: 6000,
-          },
-        ],
-      },
-    };
+    const ridership: ConsolidatedRidership = makeConsolidatedRidership(
+      802,
+      [
+        makeRidershipRecord({
+          year: 2023,
+          month: 6,
+          line_name: 802,
+          est_wkday_ridership: 12000,
+          est_sat_ridership: 8000,
+          est_sun_ridership: 6000,
+        }),
+      ],
+      { selected: true },
+    );
     const csv = decodeURI(generateCSV(ridership));
     expect(csv).toContain('B Line');
     expect(csv).not.toContain('802');
   });
 
   it('includes multiple records for the same line', () => {
-    const ridership: ConsolidatedRidership = {
-      '801': {
-        selected: true,
-        ridershipRecords: [
-          {
-            year: 2022,
-            month: 1,
-            line_name: 801,
-            est_wkday_ridership: 1000,
-            est_sat_ridership: null,
-            est_sun_ridership: null,
-          },
-          {
-            year: 2022,
-            month: 2,
-            line_name: 801,
-            est_wkday_ridership: 2000,
-            est_sat_ridership: null,
-            est_sun_ridership: null,
-          },
-        ],
-      },
-    };
+    const ridership: ConsolidatedRidership = makeConsolidatedRidership(
+      801,
+      [
+        makeRidershipRecord({
+          month: 1,
+          est_wkday_ridership: 1000,
+          est_sat_ridership: null,
+          est_sun_ridership: null,
+        }),
+        makeRidershipRecord({
+          month: 2,
+          est_wkday_ridership: 2000,
+          est_sat_ridership: null,
+          est_sun_ridership: null,
+        }),
+      ],
+      { selected: true },
+    );
     const csv = decodeURI(generateCSV(ridership));
     expect(csv).toContain('1000');
     expect(csv).toContain('2000');

--- a/src/utils/mapPopup.test.ts
+++ b/src/utils/mapPopup.test.ts
@@ -1,16 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildPopupHTML } from './mapPopup';
-import type { Line } from '../@types/lines.types';
-
-const makeLine = (overrides: Partial<Line> = {}): Line => ({
-  id: 801,
-  name: 'A Line',
-  mode: 'Rail',
-  provider: 'DO',
-  selected: true,
-  visible: true,
-  ...overrides,
-});
+import { makeLine } from '../test/builders';
 
 describe('buildPopupHTML', () => {
   it('always includes the line name in bold', () => {


### PR DESCRIPTION
Closes #104. Last open sub-issue of #100, and independent of the rest of that stack.

## What changed

Seven test files each declared their own near-identical fixture factory. They now come from one module, `src/test/builders.ts`:

| Was | Where | Now |
| --- | --- | --- |
| `makeLine` ×5 | `utils/lines.test.ts`, `utils/mapPopup.test.ts`, `components/Map.test.tsx`, `components/OutputArea.test.tsx`, `components/SummaryData.test.tsx` | `makeLine` |
| `makeRidership` | `hooks/useUserDashboardInput.test.ts` | `makeConsolidatedRidership` + `makeRidershipRecord` |
| `makeRecord`, `makeEvent` | `ridership/buildRidershipView.test.ts` | `makeRidershipRecord`, `makeTransitEvent` |
| 4 inline `ConsolidatedRidership` literals | `utils/lines.test.ts` | `makeConsolidatedRidership` |

The issue lists six sites; the seventh (`buildRidershipView.test.ts`, added in #107 with deliberately local fixtures) is folded in here too — its 1000 / 600 / 400 defaults were the only ones any call site actually leaned on, so they became the shared defaults and that file kept its meaning exactly.

Test-only. No production source touched: `src/@types/`, `src/ridership/` implementation, `src/utils/` implementation and all of `e2e/` are untouched, and no PNG baseline was regenerated (nothing rendered changes).

## The three open questions, decided

Recorded here so you can overrule rather than discover.

**1. Defaults.** Reconciled to the majority shape; no assertion changed meaning.

- `makeLine` → `{ id: 801, name: 'A Line', mode: 'Rail', provider: 'DO', selected: false, visible: true }`. Four of the five copies already used this. The outliers were `utils/lines.test.ts` (a generic `id: 1 / 'Line 1' / Bus`) and `utils/mapPopup.test.ts` (`selected: true`). Neither dependence was real: `lineNameSortFunction` reads only `name` and — for two `Line N` names — `id`, and every one of those cases either overrides `name` alone (so the `id` tiebreak is never reached) or states both ids explicitly; `buildPopupHTML` reads only `distanceMiles` / `averageRidership` / `ridersPerMile` and never `selected` or `mode`.
- `makeRidershipRecord` → `{ year: 2022, month: 1, line_name: 801, est_wkday_ridership: 1000, est_sat_ridership: 600, est_sun_ridership: 400 }`. The ridership figures come from `buildRidershipView.test.ts`, the only site that relied on defaulted numbers. Every other site states its own, including the `null` weekend fields in `lines.test.ts` and the hook test.
- `selected` defaults to `false` in **both** `makeLine` and `makeConsolidatedRidership`, so the four sites that need `true` now say so. Line Selection is the axis most of these tests are varying — it belongs at the call site, not in a default. This is the one place a default was flipped rather than adopted (the old `makeRidership` and three of the four inline literals hardcoded `true`); each of those call sites now passes `{ selected: true }` explicitly.

**2. Where the file lands: `src/test/builders.ts` is safe.** Vitest's include glob is the default `**/*.{test,spec}.?(c|m)[jt]s?(x)` (`vitest.config.ts` overrides only `exclude`), which `builders.ts` does not match. Confirmed empirically — the file count is still 18, so it was not collected. It sits beside the existing `src/test-setup.ts` for the same reason: test-only scaffolding, never imported by application code. No alternate location was needed.

**3. Builders return plain, unfrozen objects.** Nothing in the suite mutates a fixture (checked), and each call mints a fresh object, so cross-test bleed is already impossible. A meaningful guard would need a deep freeze over the nested `ridershipRecords` / `line_ids` arrays — more machinery than the problem warrants, and a trap for a future test that legitimately wants to mutate. Reconsider if a shared frozen constant ever appears.

## Verification

```
$ npm run lint
(clean)

$ npm run test
 Test Files  18 passed (18)
      Tests  384 passed (384)

$ npm run build
✓ built in 12.16s
```

Before (`main`): **18 files, 384 tests.** After: **18 files, 384 tests.** No test added, removed, renamed or re-asserted — the diff is 149 insertions / 192 deletions, all of it fixture construction.

`npm run test:e2e` was not run: nothing rendered changes, and a first local run on Windows writes `-win32.png` scratch from this branch, so it would not be a guard anyway. No baseline was regenerated.

## Out of scope

Letters C, E and G from the architecture review (`updateLinesWithLineMetrics`, `src/utils/calc.ts`, the month encodings) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
