### PR TITLE
docs: point letter E at PR #93 before it grills candidate 3

### DIFF
--- a/docs/architecture-review-2026-08-05.md
+++ b/docs/architecture-review-2026-08-05.md
@@ -28,7 +28,7 @@ opens the PR. Letters run in one series and are never reused. Batch prefix:
 | B | 1 — ridership view module | implement → PR | **done** — #105, #106, #107, #108 |
 | C | 2 — derived metrics off state | grill → spec → tickets | **ready** |
 | D | 2 — derived metrics off state | implement → PR | blocked by C |
-| E | 3 — collapse `calc.ts` | grill → spec → tickets | **ready** |
+| E | 3 — collapse `calc.ts` | grill → spec → tickets | **ready** — read PR #93 first |
 | F | 3 — collapse `calc.ts` | implement → PR | blocked by E |
 | G | 4 — a `Month` module | grill → spec → tickets | **ready** |
 | H | 4 — a `Month` module | implement → PR | blocked by G |
@@ -162,6 +162,19 @@ Four `JSON.stringify` dependency arrays exist to keep that cycle from spinning.
 **Files** — `src/utils/calc.ts` · `src/utils/calc.test.ts` ·
 `src/hooks/useUserDashboardInput.ts` (L193–213)
 
+> **Read PR #93 before grilling E.** It is open against this exact territory and closes #88.
+> It already fixes the in-place `metrics.sort()` mutation and the unguarded `sorted[0]`, and it
+> takes a deliberate policy decision — *label, don't redefine* — that the "coverage-aware"
+> column below assumes rather than argues: metrics keep estimating from each line's own first
+> and last record, and the UI stops claiming they all describe the same period. Re-anchoring
+> them to the window endpoints is explicitly deferred there as its own decision. E should either
+> build on that policy or reopen it on purpose, not rediscover it.
+>
+> Two mechanical notes: #93 predates the candidate 1 work, so it edits `src/utils/chartData.ts`,
+> which #106 moved to `src/ridership/`, and it touches `SummaryData.test.tsx` and
+> `useUserDashboardInput.test.ts`, whose fixtures #110 rewrote. It needs a rebase before either
+> it or E can land. Whichever goes second absorbs that cost — worth deciding the order up front.
+
 **Problem.** Five exports that always fire together, each re-sorting the caller's array **in
 place**, and the caller must know to skip `calcRidersPerMile` when distance is missing. The
 module is shallow — its interface is nearly as complex as its implementation.
@@ -192,7 +205,7 @@ coverage-awareness gets exactly one place to land.
 
 **Strong** · in-process
 
-**Files** — `src/App.tsx` · `src/utils/chartData.ts` (`timeKey`) ·
+**Files** — `src/App.tsx` · `src/ridership/chartData.ts` (`timeKey`) ·
 `src/components/OutputArea.tsx` (`eventMarkers`, `formatMonthLabel`) · `src/utils/queryParams.ts`
 · `src/utils/dataDateRange.ts`
 


### PR DESCRIPTION
Docs only — no code.

## Why

[#93](https://github.com/streetsforall/metro_ridership_app/pull/93) is open against `src/utils/calc.ts` and closes #88 — the same territory letter E is scheduled to grill. Nothing in the review doc mentioned it, so E would have started from a blank sheet against code that has an open PR reshaping it.

Two things E specifically needs from #93:

- **A policy decision already taken.** #93 chose *label, don't redefine*: the metrics keep estimating from each line's own first and last record, and the UI stops claiming they all describe the same period. Re-anchoring to the window endpoints is explicitly deferred there as its own call. The candidate 3 write-up says "coverage-aware" in its after-column and assumes that outcome without arguing it. E should build on the decision or reopen it on purpose.
- **Work already done.** #93 fixes the in-place `metrics.sort()` mutation and the unguarded `sorted[0]` — both listed as candidate 3 motivations.

## Also

- **The rebase, flagged.** #93 predates candidate 1: it edits `src/utils/chartData.ts`, which #106 moved to `src/ridership/`, and it touches `SummaryData.test.tsx` and `useUserDashboardInput.test.ts`, whose fixtures #110 rewrote. Whichever of #93 or E lands second absorbs that cost, so the order is worth deciding up front.
- **Stale path fixed.** Candidate 4's file list still pointed at `src/utils/chartData.ts`. Corrected to `src/ridership/chartData.ts` — that one is forward-looking guidance for letter G, so a wrong path actively misleads. Candidate 1's file list keeps the old path deliberately: it records the before-state that candidate 1 addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
