### PR TITLE
refactor(ridership): destructure events with the rest of the input

### DIFF
--- a/src/ridership/buildRidershipView.ts
+++ b/src/ridership/buildRidershipView.ts
@@ -71,8 +71,15 @@ export interface RidershipView {
  * appear for a given URL.
  */
 export function buildRidershipView(input: RidershipViewInput): RidershipView {
-  const { records, lines, startDate, endDate, dayOfWeek, includeAggregate } =
-    input;
+  const {
+    records,
+    lines,
+    startDate,
+    endDate,
+    dayOfWeek,
+    includeAggregate,
+    events: inputEvents,
+  } = input;
 
   const consolidatedRidership: ConsolidatedRidership = {};
 
@@ -159,7 +166,7 @@ export function buildRidershipView(input: RidershipViewInput): RidershipView {
     });
   }
 
-  const allEvents = input.events ?? (transitEventsData as TransitEvent[]);
+  const allEvents = inputEvents ?? (transitEventsData as TransitEvent[]);
 
   /**
    * The Event Window: inclusive on both ends and 1-based, unlike the Month


### PR DESCRIPTION
No-op readability cleanup in `src/ridership/buildRidershipView.ts`. No issue — came out of a post-merge review of #106/#107/#108 as a below-the-bar cosmetic note.

## What was inconsistent

`buildRidershipView` opened by destructuring six of the seven fields of `RidershipViewInput`, then read the seventh — the optional `events` override — ~90 lines further down as `input.events`. Someone skimming the opening lines saw six inputs and missed that the injectable override the entire event-filter test suite depends on exists at all.

## Change

`events: inputEvents` joins the destructure; the `allEvents` line uses that local.

```diff
-  const { records, lines, startDate, endDate, dayOfWeek, includeAggregate } =
-    input;
+  const {
+    records,
+    lines,
+    startDate,
+    endDate,
+    dayOfWeek,
+    includeAggregate,
+    events: inputEvents,
+  } = input;
...
-  const allEvents = input.events ?? (transitEventsData as TransitEvent[]);
+  const allEvents = inputEvents ?? (transitEventsData as TransitEvent[]);
```

`inputEvents` avoids shadowing the returned `RidershipView.events` field and the `const events = allEvents.filter(...).sort(...)` local near the bottom. Defaulting stays at the original site with `??` intact, so a caller passing an empty array still gets an empty array rather than the bundled data.

## Not changed

- No exported type touched (`RidershipViewInput`, `RidershipView`, `LineSelection`).
- No logic, ordering, or defaulting semantics.
- The deliberate `Date` offset in the record-filter loop, per `docs/adr/0001-ridership-month-window-is-deliberately-offset.md`.
- All existing comments.

## Verification

`npm run lint`, `npm test` (384/384 passing, 18 files), `npm run build` all clean. No e2e run — nothing rendered changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)