### PR TITLE
test(ridership): assert the bundled event by id, not by count

### DIFF
--- a/src/ridership/buildRidershipView.test.ts
+++ b/src/ridership/buildRidershipView.test.ts
@@ -515,9 +515,9 @@ describe('buildRidershipView — event selection filtering', () => {
       includeAggregate: false,
     });
 
-    // The K Line's Regional Connector opening (2023-06) is in the bundled data
-    // and inside this window.
-    expect(events.length).toBeGreaterThan(0);
+    // k-line-opening (2022-10, line_ids [807]) is the bundled event this window
+    // admits.
+    expect(events.map((e) => e.id)).toContain('k-line-opening');
     for (const event of events)
       expect(
         event.line_ids.length === 0 || event.line_ids.includes(807),


### PR DESCRIPTION
Closes #113

## Problem

`it('defaults to the bundled transit-events.json when no events are given')` in [src/ridership/buildRidershipView.test.ts](src/ridership/buildRidershipView.test.ts) passed for a reason other than the one documented.

The comment credited "the K Line's Regional Connector opening (2023-06)". But `regional-connector-opening` in `src/data/transit-events.json` has `"line_ids": [801, 803, 804, 806]` — 807 is not among them, so that event is filtered *out* by this very call. The Regional Connector is the A/C/E/L through-running project and has nothing to do with the K Line. The event that actually satisfies the assertion is `k-line-opening` (`"date": "2022-10"`, `"line_ids": [807]`).

Separately, `expect(events.length).toBeGreaterThan(0)` is a count assertion over hand-maintained data. If `k-line-opening` is ever re-dated or removed, the test goes red pointing at the derivation module rather than at the data edit.

## Change

- Comment now names `k-line-opening` (2022-10, `line_ids [807]`) as the bundled event this window admits.
- `expect(events.length).toBeGreaterThan(0)` → `expect(events.map((e) => e.id)).toContain('k-line-opening')`, so a future data edit fails with a legible message.

The loop asserting every returned event is system-wide or includes 807 is unchanged — that is what proves the default path is genuinely filtered. `buildRidershipView.ts` is untouched.

## Verification

`npm run lint`, `npm test` (384 passed), `npm run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
