### PR TITLE
refactor(ridership): rename `RidershipView.byLine` to `consolidated`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,10 +69,10 @@ function App() {
    * deliberately offset month window, the shared axis, the aggregate ordering)
    * lives in src/ridership/ and is unit-tested there.
    *
-   * Kept memoised: the metrics effect below keys on JSON.stringify(byLine), and
+   * Kept memoised: the metrics effect below keys on JSON.stringify(consolidated), and
    * a fresh object every render would thrash it.
    */
-  const { months, datasets, byLine, events } = useMemo(
+  const { months, datasets, consolidated, events } = useMemo(
     () =>
       buildRidershipView({
         records: ridershipRecords,
@@ -88,12 +88,12 @@ function App() {
   /**
    * Attach computed metrics (average ridership, change, etc.) to each line entry
    * so the LineSelector can display them. JSON.stringify is used as the dependency
-   * because byLine is a new object reference on every render (useMemo).
+   * because consolidated is a new object reference on every render (useMemo).
    */
   useEffect(() => {
-    updateLinesWithLineMetrics(byLine);
+    updateLinesWithLineMetrics(consolidated);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(byLine)]);
+  }, [JSON.stringify(consolidated)]);
 
   return (
     /* Stretch full height */
@@ -126,7 +126,7 @@ function App() {
           <LineSelector
             {...userDashboardInputState}
             lines={visibleLines}
-            ridershipByLine={byLine}
+            ridershipByLine={consolidated}
             isExpanded={isLineSelectorExpanded}
             setIsExpanded={setIsLineSelectorExpanded}
           />

--- a/src/plans/ridership-view-module.md
+++ b/src/plans/ridership-view-module.md
@@ -161,13 +161,18 @@ export interface RidershipView {
   /** One dataset per selected line in `lines` order; the Aggregate Series last, if requested. */
   datasets: ChartDataset<'line', CustomChartData[]>[];
   /** Records grouped by line, each carrying its Selection Snapshot. */
-  byLine: ConsolidatedRidership;
+  consolidated: ConsolidatedRidership;
   /** Transit Events inside the Event Window that apply to the selection, chronologically. */
   events: TransitEvent[];
 }
 
 export function buildRidershipView(input: RidershipViewInput): RidershipView;
 ```
+
+> **Naming (issue #114):** this plan originally called the third field `byLine`, which is the
+> synonym `CONTEXT.md:84-87` lists under _Avoid_ for **Consolidated Ridership**. Per the glossary's
+> precedence rule (`CONTEXT.md:8-9`) the term wins and the plan was the out-of-date document, so the
+> field is `consolidated` here and in the source.
 
 The body is the two `App.tsx` memos, moved. Specifically:
 
@@ -180,7 +185,7 @@ worked-out rule:
 > `docs/adr/0001-ridership-month-window-is-deliberately-offset.md`.
 
 **4b — Select, axis, align.** Lift L117–148 verbatim. `selected` is `lines.filter(line =>
-byLine[line.id]?.selected)` — note it filters on the **Selection Snapshot**, not on
+consolidated[line.id]?.selected)` — note it filters on the **Selection Snapshot**, not on
 `line.selected`, so a line selected but with no records in the window produces no dataset.
 
 **4c — Aggregate.** Lift L150–163, gated on `includeAggregate` instead of `isAggregateVisible`.
@@ -196,7 +201,7 @@ snapshot. That differs from 4b and is not an oversight: an event on a line with 
 window still shows. Preserve it, and say so in a comment.
 
 **4e — The empty view.** When `records` is `null`, the grouping loop simply does not run, so
-`byLine` is `{}`, `selected` is empty, `months` is `[]` and `datasets` is `[]`. Events are **still
+`consolidated` is `{}`, `selected` is empty, `months` is `[]` and `datasets` is `[]`. Events are **still
 filtered and returned** — they do not depend on records. Confirm this matches today: in `App.tsx`
 the events memo does not depend on `ridershipRecords`, so it already returns events during loading.
 Preserve that.
@@ -268,7 +273,7 @@ Cases to cover:
 
 **New — the empty view:**
 
-- `records: null` → `{ months: [], datasets: [], byLine: {} }`
+- `records: null` → `{ months: [], datasets: [], consolidated: {} }`
 - `records: null` still returns the filtered events
 
 ### Step 6 — Point the index at the module
@@ -296,7 +301,7 @@ PR is behaviour drift** — that is the whole reason it is its own PR.
 ### Step 7 — Replace both memos in `App.tsx`
 
 ```tsx
-const { months, datasets, byLine, events } = useMemo(
+const { months, datasets, consolidated, events } = useMemo(
   () =>
     buildRidershipView({
       records: ridershipRecords,
@@ -319,15 +324,15 @@ unused, `transitEventsData` and the `TransitEvent` / `ConsolidatedRidership` / `
 `CustomChartData` type imports if now unused, and both memo bodies. Verify with `npm run lint`.
 
 Rename at the call sites: `chartDatasets` → `datasets`, `monthList` → `months`, `ridershipByLine` →
-`byLine`, `transitEvents` → `events`. **`OutputArea` and `LineSelector` prop names do not change** —
+`consolidated`, `transitEvents` → `events`. **`OutputArea` and `LineSelector` prop names do not change** —
 only the local variable bound to them:
 
 ```tsx
-<LineSelector ... ridershipByLine={byLine} />
+<LineSelector ... ridershipByLine={consolidated} />
 <OutputArea chartDatasets={datasets} months={months} lines={lines} transitEvents={events} ... />
 ```
 
-`updateLinesWithLineMetrics(byLine)` and its `JSON.stringify` dependency stay exactly as they are —
+`updateLinesWithLineMetrics(consolidated)` and its `JSON.stringify` dependency stay exactly as they are —
 unwinding that write-back loop is candidate 2, not this work.
 
 ### Step 8 — Drop the chart-helper exports from the index

--- a/src/ridership/buildRidershipView.test.ts
+++ b/src/ridership/buildRidershipView.test.ts
@@ -211,7 +211,7 @@ describe('buildRidershipView — the Month Window', () => {
   });
 
   it('produces no dataset for a selected line with no records in the window', () => {
-    const { datasets, byLine } = build({
+    const { datasets, consolidated } = build({
       lines: [K],
       startDate: month(2023, 6),
       endDate: month(2024, 6),
@@ -220,7 +220,7 @@ describe('buildRidershipView — the Month Window', () => {
     expect(datasets).toHaveLength(0);
     // The line is absent from the grouping entirely, so there is no Selection
     // Snapshot for the dataset loop to filter on.
-    expect(byLine[807]).toBeUndefined();
+    expect(consolidated[807]).toBeUndefined();
   });
 
   /**
@@ -375,13 +375,13 @@ describe('buildRidershipView — data point shape', () => {
 
 describe('buildRidershipView — Consolidated Ridership', () => {
   it('groups records by line and records the Selection Snapshot', () => {
-    const { byLine } = build({ lines: [K, { id: 806, selected: false }] });
+    const { consolidated } = build({ lines: [K, { id: 806, selected: false }] });
 
-    expect(byLine[807].selected).toBe(true);
-    expect(byLine[807].ridershipRecords).toHaveLength(3);
+    expect(consolidated[807].selected).toBe(true);
+    expect(consolidated[807].ridershipRecords).toHaveLength(3);
     // Grouped even when unselected — the snapshot is what the dataset loop reads.
-    expect(byLine[806].selected).toBe(false);
-    expect(byLine[806].ridershipRecords).toHaveLength(1);
+    expect(consolidated[806].selected).toBe(false);
+    expect(consolidated[806].ridershipRecords).toHaveLength(1);
   });
 });
 
@@ -526,12 +526,12 @@ describe('buildRidershipView — event selection filtering', () => {
 });
 
 describe('buildRidershipView — the empty view', () => {
-  it('yields empty months, datasets and byLine while records are null', () => {
-    const { months, datasets, byLine } = build({ records: null, lines: [K, L] });
+  it('yields empty months, datasets and consolidated while records are null', () => {
+    const { months, datasets, consolidated } = build({ records: null, lines: [K, L] });
 
     expect(months).toEqual([]);
     expect(datasets).toEqual([]);
-    expect(byLine).toEqual({});
+    expect(consolidated).toEqual({});
   });
 
   it('still filters and returns events while records are null', () => {

--- a/src/ridership/buildRidershipView.ts
+++ b/src/ridership/buildRidershipView.ts
@@ -44,7 +44,7 @@ export interface RidershipView {
   /** One dataset per selected line in `lines` order; the Aggregate Series last, if requested. */
   datasets: ChartDataset<'line', CustomChartData[]>[];
   /** Records grouped by line, each carrying its Selection Snapshot. */
-  byLine: ConsolidatedRidership;
+  consolidated: ConsolidatedRidership;
   /** Transit Events inside the Event Window that apply to the selection, chronologically. */
   events: TransitEvent[];
 }
@@ -199,7 +199,7 @@ export function buildRidershipView(input: RidershipViewInput): RidershipView {
   return {
     months,
     datasets,
-    byLine: consolidatedRidership,
+    consolidated: consolidatedRidership,
     events,
   };
 }


### PR DESCRIPTION
Closes #114.

## What renamed

`RidershipView.byLine` → **`consolidated`**, plus the two things that read it:

- [src/ridership/buildRidershipView.ts](src/ridership/buildRidershipView.ts) — the interface field and the return object. The JSDoc already stated the concept correctly and is unchanged.
- [src/ridership/buildRidershipView.test.ts](src/ridership/buildRidershipView.test.ts) — destructures and assertions follow.
- [src/App.tsx](src/App.tsx) — the local binding from the `buildRidershipView` `useMemo`, the metrics `useEffect` (`updateLinesWithLineMetrics(consolidated)` and its `JSON.stringify` dep), and the two comments that name it.
- [src/plans/ridership-view-module.md](src/plans/ridership-view-module.md) — the plan specified `byLine` (`:164`, and Step 7's rename table), so it follows the rename and gains a one-line note recording that #114 settled the plan-vs-glossary conflict in the glossary's favour. Nothing else in the plan changed.

`src/ridership/index.ts` needed no change — it re-exports the type, not the field.

## Why `consolidated`, and why the plan rather than the glossary moved

`CONTEXT.md:84-87` defines **Consolidated Ridership** and lists _ridership by line_ under _Avoid_; `CONTEXT.md:8-9` sets the precedence rule that the glossary wins and the source is what's out of date. `byLine` was that avoided synonym, shortened. #114 left open whether to rename or amend the glossary — the precedence rule decides it, so `CONTEXT.md` is untouched.

## Not touched, deliberately

- `LineSelector`'s **`ridershipByLine` prop name** — a component API outside this module's scope; the issue explicitly allows it to stay. Only the value passed to it renames (`ridershipByLine={consolidated}`).
- `CONTEXT.md`, `src/utils/calc.ts`, `chartData` internals, e2e baselines.

## No behaviour change

Pure rename of a field on a type with one consumer. No baseline PNG changed (`git status` is clean of image diffs), and the e2e suite passes against the committed Linux baselines' local equivalents without regeneration.

## Verify gate

| Command | Result |
| --- | --- |
| `npm run lint` | clean, no warnings |
| `npm test` | **384 passed** (18 files) |
| `npm run build` | ✓ built in 14.85s (tsc -b clean) |
| `npm run test:e2e` | **20/20 passed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
