### PR TITLE
refactor(ridership): add lineMetrics module and its test

### DIFF
--- a/src/ridership/index.ts
+++ b/src/ridership/index.ts
@@ -29,3 +29,13 @@ export {
   buildWindowMonthAxis,
   type LineCoverage,
 } from './chartData';
+
+/**
+ * The per-line summary figures the line table and the summary panel read.
+ * Replaces the five exports of the former `src/utils/calc.ts`.
+ */
+export {
+  lineMetrics,
+  type LineMetrics,
+  type LineMetricsInput,
+} from './lineMetrics';

--- a/src/ridership/lineMetrics.test.ts
+++ b/src/ridership/lineMetrics.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect } from 'vitest';
+import { lineMetrics } from './lineMetrics';
+import { makeRidershipRecord } from '../test/builders';
+
+/**
+ * Keeps the cases ported from `src/utils/calc.test.ts` at their original positional
+ * readability. Three lines and file-local — not a new record factory: it wraps the
+ * shared `makeRidershipRecord`, which is what `src/test/builders.ts` exists to enforce.
+ */
+const at = (
+  year: number,
+  month: number,
+  wkday: number | null,
+  sat: number | null = null,
+  sun: number | null = null,
+) =>
+  makeRidershipRecord({
+    year,
+    month,
+    est_wkday_ridership: wkday,
+    est_sat_ridership: sat,
+    est_sun_ridership: sun,
+  });
+
+// Unsorted: March, January, June
+const records = [
+  at(2022, 3, 1000, 500, 300),
+  at(2022, 1, 2000, 800, 400),
+  at(2022, 6, 3000, 1200, 600),
+];
+
+const metricsFor = (input: Parameters<typeof lineMetrics>[0]) => {
+  const result = lineMetrics(input);
+  if (!result) throw new Error('expected metrics');
+  return result;
+};
+
+describe('averageRidership', () => {
+  it('returns the average weekday ridership', () => {
+    expect(
+      metricsFor({ records, dayOfWeek: 'est_wkday_ridership' })
+        .averageRidership,
+    ).toBe(2000);
+  });
+
+  it('returns the average saturday ridership', () => {
+    expect(
+      metricsFor({ records, dayOfWeek: 'est_sat_ridership' }).averageRidership,
+    ).toBeCloseTo(833.33, 1);
+  });
+
+  it('returns the average sunday ridership', () => {
+    expect(
+      metricsFor({ records, dayOfWeek: 'est_sun_ridership' }).averageRidership,
+    ).toBeCloseTo(433.33, 1);
+  });
+
+  it('treats null values as 0', () => {
+    const mixed = [at(2022, 1, null), at(2022, 2, 3000)];
+    expect(
+      metricsFor({ records: mixed, dayOfWeek: 'est_wkday_ridership' })
+        .averageRidership,
+    ).toBe(1500);
+  });
+
+  it('handles a single record', () => {
+    expect(
+      metricsFor({
+        records: [at(2022, 1, 500)],
+        dayOfWeek: 'est_wkday_ridership',
+      }).averageRidership,
+    ).toBe(500);
+  });
+
+  it('handles all-null values as average of 0s', () => {
+    const nulls = [at(2022, 1, null), at(2022, 2, null)];
+    expect(
+      metricsFor({ records: nulls, dayOfWeek: 'est_wkday_ridership' })
+        .averageRidership,
+    ).toBe(0);
+  });
+});
+
+describe('changeInRidership', () => {
+  it('returns last minus first ridership after sorting by date', () => {
+    // Sorted: Jan=2000, Mar=1000, Jun=3000 → last - first = 3000 - 2000 = 1000
+    expect(
+      metricsFor({ records, dayOfWeek: 'est_wkday_ridership' })
+        .changeInRidership,
+    ).toBe(1000);
+  });
+
+  it('returns negative value when ridership declined', () => {
+    const declining = [at(2022, 1, 5000), at(2022, 6, 2000)];
+    expect(
+      metricsFor({ records: declining, dayOfWeek: 'est_wkday_ridership' })
+        .changeInRidership,
+    ).toBe(-3000);
+  });
+
+  it('returns 0 for a single record', () => {
+    expect(
+      metricsFor({
+        records: [at(2022, 1, 1000)],
+        dayOfWeek: 'est_wkday_ridership',
+      }).changeInRidership,
+    ).toBe(0);
+  });
+
+  it('sorts by year then month across multiple years', () => {
+    const multiYear = [at(2023, 1, 8000), at(2021, 6, 4000)];
+    expect(
+      metricsFor({ records: multiYear, dayOfWeek: 'est_wkday_ridership' })
+        .changeInRidership,
+    ).toBe(4000);
+  });
+
+  it('treats null as 0 for both endpoints', () => {
+    const withNull = [at(2022, 1, null), at(2022, 6, 3000)];
+    expect(
+      metricsFor({ records: withNull, dayOfWeek: 'est_wkday_ridership' })
+        .changeInRidership,
+    ).toBe(3000);
+  });
+
+  it('works for saturday ridership', () => {
+    // Sorted: Jan=800, Mar=500, Jun=1200 → 1200 - 800 = 400
+    expect(
+      metricsFor({ records, dayOfWeek: 'est_sat_ridership' }).changeInRidership,
+    ).toBe(400);
+  });
+});
+
+describe('endingRidership', () => {
+  it('returns the most recent weekday ridership', () => {
+    // Sorted chronologically, last is June=3000
+    expect(
+      metricsFor({ records, dayOfWeek: 'est_wkday_ridership' }).endingRidership,
+    ).toBe(3000);
+  });
+
+  it('returns the most recent saturday ridership', () => {
+    expect(
+      metricsFor({ records, dayOfWeek: 'est_sat_ridership' }).endingRidership,
+    ).toBe(1200);
+  });
+
+  it('handles a single record', () => {
+    expect(
+      metricsFor({
+        records: [at(2022, 1, 999)],
+        dayOfWeek: 'est_wkday_ridership',
+      }).endingRidership,
+    ).toBe(999);
+  });
+
+  it('treats a null last value as 0', () => {
+    const withNull = [at(2022, 1, 500), at(2022, 6, null)];
+    expect(
+      metricsFor({ records: withNull, dayOfWeek: 'est_wkday_ridership' })
+        .endingRidership,
+    ).toBe(0);
+  });
+
+  it('picks the later year as the end', () => {
+    const multiYear = [at(2023, 1, 9000), at(2021, 12, 1000)];
+    expect(
+      metricsFor({ records: multiYear, dayOfWeek: 'est_wkday_ridership' })
+        .endingRidership,
+    ).toBe(9000);
+  });
+});
+
+describe('startingRidership', () => {
+  it('returns the earliest weekday ridership', () => {
+    // Sorted chronologically, first is January=2000
+    expect(
+      metricsFor({ records, dayOfWeek: 'est_wkday_ridership' })
+        .startingRidership,
+    ).toBe(2000);
+  });
+
+  it('returns the earliest saturday ridership', () => {
+    expect(
+      metricsFor({ records, dayOfWeek: 'est_sat_ridership' }).startingRidership,
+    ).toBe(800);
+  });
+
+  it('handles a single record', () => {
+    expect(
+      metricsFor({
+        records: [at(2022, 1, 750)],
+        dayOfWeek: 'est_wkday_ridership',
+      }).startingRidership,
+    ).toBe(750);
+  });
+
+  it('treats a null first value as 0', () => {
+    const withNull = [at(2022, 1, null), at(2022, 6, 500)];
+    expect(
+      metricsFor({ records: withNull, dayOfWeek: 'est_wkday_ridership' })
+        .startingRidership,
+    ).toBe(0);
+  });
+
+  it('picks the earlier year as the start', () => {
+    const multiYear = [at(2023, 1, 9000), at(2021, 12, 1000)];
+    expect(
+      metricsFor({ records: multiYear, dayOfWeek: 'est_wkday_ridership' })
+        .startingRidership,
+    ).toBe(1000);
+  });
+});
+
+describe('an empty series', () => {
+  // No records means no metrics, not zeroes. The caller's existing
+  // "this line has nothing" branch handles null — see ADR-0004. This collapses the
+  // three per-function empty guards `calc.test.ts` carried; there is one function now.
+  it('returns null', () => {
+    expect(
+      lineMetrics({ records: [], dayOfWeek: 'est_wkday_ridership' }),
+    ).toBeNull();
+  });
+});
+
+describe('input is not mutated', () => {
+  // The array handed in is the live ridershipRecords array inside ridershipByLine,
+  // which also backs the row sparklines and the CSV export — sorting it in place
+  // reorders data other callers are reading.
+  const unsorted = () => [
+    at(2022, 3, 1000),
+    at(2022, 1, 2000),
+    at(2022, 6, 3000),
+  ];
+
+  it('leaves the caller order intact', () => {
+    const input = unsorted();
+    lineMetrics({ records: input, dayOfWeek: 'est_wkday_ridership' });
+    expect(input.map((r) => r.month)).toEqual([3, 1, 6]);
+  });
+
+  it('still returns the chronological endpoints from an unsorted input', () => {
+    const input = unsorted();
+    const m = metricsFor({
+      records: input,
+      dayOfWeek: 'est_wkday_ridership',
+    });
+    expect(m.startingRidership).toBe(2000);
+    expect(m.endingRidership).toBe(3000);
+    expect(m.changeInRidership).toBe(1000);
+  });
+});
+
+describe('ridersPerMile', () => {
+  it('divides average ridership by distance', () => {
+    const m = metricsFor({
+      records: [at(2022, 1, 10000)],
+      dayOfWeek: 'est_wkday_ridership',
+      distanceMiles: 20,
+    });
+    expect(m.ridersPerMile).toBe(500);
+  });
+
+  it('returns a decimal when ridership does not divide evenly', () => {
+    const m = metricsFor({
+      records: [at(2022, 1, 1000)],
+      dayOfWeek: 'est_wkday_ridership',
+      distanceMiles: 3,
+    });
+    expect(m.ridersPerMile).toBeCloseTo(333.33, 1);
+  });
+
+  it('returns 0 when ridership is 0', () => {
+    const m = metricsFor({
+      records: [at(2022, 1, 0)],
+      dayOfWeek: 'est_wkday_ridership',
+      distanceMiles: 15,
+    });
+    expect(m.ridersPerMile).toBe(0);
+  });
+
+  it('divides the average by the distance', () => {
+    const m = metricsFor({
+      records,
+      dayOfWeek: 'est_wkday_ridership',
+      distanceMiles: 10,
+    });
+    expect(m.ridersPerMile).toBe(200);
+  });
+
+  // Preserves `if (updatedLine.distanceMiles)` from the former call site: a falsy
+  // distance means no figure, never Infinity and never NaN.
+  it('is undefined when the distance is absent', () => {
+    const m = metricsFor({ records, dayOfWeek: 'est_wkday_ridership' });
+    expect(m.ridersPerMile).toBeUndefined();
+  });
+
+  it('is undefined when the distance is 0', () => {
+    const m = metricsFor({
+      records,
+      dayOfWeek: 'est_wkday_ridership',
+      distanceMiles: 0,
+    });
+    expect(m.ridersPerMile).toBeUndefined();
+  });
+
+  // Always written, never omitted, so spreading onto a Line clears a stale figure.
+  it('is present as a key even when undefined', () => {
+    const m = metricsFor({ records, dayOfWeek: 'est_wkday_ridership' });
+    expect('ridersPerMile' in m).toBe(true);
+  });
+});
+
+describe('one call, all five figures', () => {
+  it('returns every figure from a single call', () => {
+    const m = metricsFor({
+      records,
+      dayOfWeek: 'est_wkday_ridership',
+      distanceMiles: 10,
+    });
+    expect(m).toEqual({
+      averageRidership: 2000,
+      changeInRidership: 1000,
+      startingRidership: 2000,
+      endingRidership: 3000,
+      ridersPerMile: 200,
+    });
+  });
+});

--- a/src/ridership/lineMetrics.ts
+++ b/src/ridership/lineMetrics.ts
@@ -1,0 +1,90 @@
+import type { DayOfWeek, RidershipRecord } from '../@types/metrics.types';
+
+/**
+ * Chronological copy of a line's records.
+ *
+ * Copies before sorting: the array handed in is the live `ridershipRecords` array
+ * inside Consolidated Ridership, which also feeds the row sparklines and the CSV
+ * export — sorting it in place reorders data other callers are reading. See PR #93,
+ * which is where that bug was fixed.
+ */
+function sortChronologically(
+  records: readonly RidershipRecord[],
+): RidershipRecord[] {
+  return [...records].sort((a, b) => {
+    if (a.year === b.year) {
+      return a.month - b.month;
+    } else {
+      return a.year - b.year;
+    }
+  });
+}
+
+export interface LineMetricsInput {
+  /** One Line's Ridership Records, in any order. Never mutated. */
+  records: readonly RidershipRecord[];
+  /** Which of the three reported figures to read. */
+  dayOfWeek: DayOfWeek;
+  /**
+   * The line's one-way route length. Falsy — `0` or absent — yields no `ridersPerMile`,
+   * which is the rule this module absorbs from its caller.
+   */
+  distanceMiles?: number;
+}
+
+export interface LineMetrics {
+  averageRidership: number;
+  changeInRidership: number;
+  startingRidership: number;
+  endingRidership: number;
+  /**
+   * `undefined` when `distanceMiles` is falsy. Declared `| undefined` rather than `?:`
+   * deliberately: the key is *always written*, so spreading `LineMetrics` onto a `Line`
+   * clears a previous window's figure instead of silently preserving it.
+   */
+  ridersPerMile: number | undefined;
+}
+
+/**
+ * The Line Metrics one line's Ridership Records yield for one Day Of Week.
+ *
+ * Sorts once, on a copy, and reads both endpoints off the same array — the five
+ * functions this replaced sorted three times for one line's figures.
+ *
+ * These figures describe the span the line itself covers, which is not necessarily the
+ * Month Window: a line whose data starts mid-window reports its own first and last
+ * record, not the window's endpoints. That is deliberate — see `buildCoverageByLine`
+ * in `./chartData`, which labels the difference in the UI rather than redefining the
+ * metric, and `docs/adr/0004-line-metrics-are-one-nullable-shape.md`.
+ *
+ * Returns `null` for an empty series. No records means no metrics, not zeroes.
+ */
+export function lineMetrics({
+  records,
+  dayOfWeek,
+  distanceMiles,
+}: LineMetricsInput): LineMetrics | null {
+  if (records.length === 0) return null;
+
+  const sorted = sortChronologically(records);
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+
+  // Divides by the record count, not by the count of non-null figures: a null month
+  // counts as 0 ridership rather than being excluded. Lifted from `calcAvg`.
+  const sum = sorted.reduce((prev, curr) => prev + (curr[dayOfWeek] ?? 0), 0);
+  const averageRidership = sum / sorted.length;
+
+  const startingRidership = first[dayOfWeek] ?? 0;
+  const endingRidership = last[dayOfWeek] ?? 0;
+
+  return {
+    averageRidership,
+    changeInRidership: endingRidership - startingRidership,
+    startingRidership,
+    endingRidership,
+    // The missing-distance rule, absorbed from the caller. A falsy distance means no
+    // figure — never Infinity, never NaN.
+    ridersPerMile: distanceMiles ? averageRidership / distanceMiles : undefined,
+  };
+}


### PR DESCRIPTION
Closes #126. **Slice 1 of 2** for #125. Spec: `src/plans/collapse-calc-into-line-metrics.md`, sections *The settled interface* / *PR 1*, Steps 1–3. Decision record: `docs/adr/0004-line-metrics-are-one-nullable-shape.md`.

## What this is

Adds `src/ridership/lineMetrics.ts` — one function returning one named `LineMetrics | null`, replacing the five always-fire-together exports of `src/utils/calc.ts`. It sorts once on a copy and reads both endpoints off the same array (the five functions cost three copy-and-sorts per line, per render), and the missing-distance rule moves inside the module.

`src/utils/calc.ts` and `src/utils/calc.test.ts` are **deliberately still live and untouched** — the new module is green but unused. The wiring and the deletion are slice 2 (#127). Isolating the new module means any red here is the new module being wrong, not the wiring; that is what makes the next slice's red mean *drift*.

Arithmetic is lifted from `calc.ts` L9–75 verbatim. `sortChronologically` moves across module-**private**, keeping its comment about why it copies (PR #93's guarantee).

## Behaviour pinned by the tests

- A `null` ridership counts as **0**, not skipped — the average divides by the record count, so an all-null series averages `0`, not `NaN`.
- Ordering is by year, then month.
- A falsy `distanceMiles` (`0` or absent) yields **no** `ridersPerMile` — never `Infinity`, never `NaN`. Typed `number | undefined`, not `?:`, so the key is always present and a spread clears a stale figure.
- An empty series returns `null` — one gate replacing five sentinels.
- The input array is never mutated.

Every behavioural case in `src/utils/calc.test.ts` has a counterpart, retargeted at the one function, per the plan's case table. The suite builds on `makeRidershipRecord` from `src/test/builders.ts` and declares no record factory of its own; the local `at(...)` is the plan's three-line wrapper that keeps ported cases readable. The `input is not mutated` block is ported with its comment intact.

## Verification

`npm run lint && npm test && npm run build` — all green (459 tests, 19 files).

`npm run test:e2e` — **20/20 passed**, committed Linux baselines untouched. Run beyond what the spec asked for (it says no e2e needed since nothing rendered changes); confirms that. The first local run reported failures only because it was writing the git-ignored `-win32.png` per-developer scratch baselines that did not exist yet in this worktree; the immediate re-run passed clean. No baseline was regenerated — `test:e2e:update*` was never run.

`git diff --stat` — exactly three files, all additive:

```
 src/ridership/index.ts            |  10 ++
 src/ridership/lineMetrics.test.ts | 329 ++++++++++++++++++++++++++++++++++++++
 src/ridership/lineMetrics.ts      |  90 +++++++++++
 3 files changed, 429 insertions(+)
```

## Defaults taken

- **The new export block goes at the end of `src/ridership/index.ts`, after the `chartData` block.** The plan's Step 2 diff shows it anchored to the `buildRidershipView` block, which in the current file is followed by the `chartData` re-exports; appending keeps the instruction "leave the existing `chartData` re-export block exactly as it is" literally true. ADR-0004 calls it "a third export group", which this is. Trivially movable if a reviewer wants it in the middle.
- **`calc.test.ts`'s three `calcRidersPerMile` cases are ported by constructing a single-record series whose average is the original numerator** (10000/20 = 500; 1000/3 ≈ 333.33; 0/15 = 0), since the figure is no longer computed by a standalone function. The four new `ridersPerMile` cases #126 lists sit alongside them in the same block.
- **The `input is not mutated` block collapses its three per-function order-intact cases into one**, for the same reason the three empty-series guards collapse: there is one function now. The "still returns the chronological endpoints from an unsorted input" case is ported unchanged.
- **`changeInRidership` is computed as `endingRidership - startingRidership`**, per the plan's Step 1 body — provably identical to `calc.ts:53`.

No discrepancies found between the spec and #126; where #126 is terser, the spec's text was followed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
