### PR TITLE
refactor(types): delete Line's four dead fields

### DIFF
--- a/src/@types/lines.types.ts
+++ b/src/@types/lines.types.ts
@@ -17,10 +17,6 @@ export interface Line {
   ridershipOverTime?: number;
   startingRidership?: number;
   endingRidership?: number;
-  division?: number;
-  viewMap?: string;
-  isAggregate?: boolean;
-  aggregatedLines?: number[];
   distanceMiles?: number;
   ridersPerMile?: number;
   /**


### PR DESCRIPTION
Part of #129 — **PR 2 of 6** (slice 2). Closes #131.

Spec: `src/plans/derived-figures-off-line-state.md`, section "PR 2 — Delete `Line`'s dead fields" (steps 5–6). ADR: `docs/adr/0005-derived-figures-live-on-line-readouts.md`.

## Why

Candidate 2's stated win is that `Line` means exactly one thing. Four vestigial fields sitting on it left that half-delivered, and they are a zero-risk delete that `tsc` checks in the same run.

Removed from `src/@types/lines.types.ts`:

| Field | Only reference |
| --- | --- |
| `division` | inside a commented-out `<td>` at `LineTableRow.tsx:235` |
| `viewMap` | inside a commented-out column block at `LineSelector.tsx:115-119` |
| `isAggregate` | none anywhere |
| `aggregatedLines` | none anywhere |

The two commented-out blocks are left **exactly** as they are — parked work; deleting commented code is a separate judgement.

`ridershipOverTime` is **not** deleted. It is also dead, but `LineSelector.tsx:112` uses it as a column key typed `keyof Line`, so removing it needs the column-key type to change — that happens in slice 5, where that type changes anyway.

`src/@types/lines.types.ts` is the only file changed. No behaviour: no field being deleted is read or written anywhere.

## Verification

```
npm run lint && npm test && npm run build
```

All green — 19 files / 459 tests passed, build clean (`tsc -b` is the proof the four fields were dead).

```
grep -rn "isAggregate\b\|aggregatedLines\|viewMap\|\.division" src/ e2e/
```

```
src/components/LineSelector.tsx:118:  //   key: 'viewMap',
src/components/LineTableRow.tsx:235:          {/* {isExpanded && <td>{line.division ?? division}</td>} */}
```

Only the two commented-out blocks (plus the spec doc, which quotes the names). `ridershipOverTime` is still present.

`npm run test:e2e` — **20/20 passed**, no baseline regenerated. See the note below on what that does and does not prove locally.

## Defaults taken

- **e2e on Windows.** This worktree had no local `-win32.png` scratch baselines, so the first run wrote them (18 "no baseline" failures) and the second run passed 20/20 against them. Those scratch baselines came from this branch, so locally they prove the render is deterministic, not that it matches `main`. The committed **`-linux.png`** baselines are untouched and are what CI compares against — that is the real gate. No `--update-snapshots` was run in any form.

```
 src/@types/lines.types.ts | 4 ----
 1 file changed, 4 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
