### PR TITLE
fixing chart overflow on xl screens

### DIFF
--- a/src/components/SummaryData.tsx
+++ b/src/components/SummaryData.tsx
@@ -44,7 +44,7 @@ export default function SummaryData({ lines }: SummaryDataProps) {
   return (
     <div>
       {selectedLines.length > 0 && (
-        <div className="flex flex-wrap xl:flex-nowrap gap-4 items-center">
+        <div className="flex flex-wrap gap-4 items-center">
           {/* Stats */}
           {/* TODO: Refactor into component */}
           <div className="pane">


### PR DESCRIPTION
Resize bug is mostly fixed, thanks for that! on my monitor it is still broken, but it is no longer a chart.js issue and now is just because `SummaryData` is overflowing at the `xl` breakpoint. Picture attached, where you can see the chart overflows.


<img width="353" height="585" alt="Screenshot 2026-08-07 at 9 56 23 AM" src="https://github.com/user-attachments/assets/e34c2f44-cf33-4482-983b-b8566f3498f8" />
