### PR TITLE
feat(ridership): add Line Readouts and the listed-lines rule

### DIFF
--- a/src/ridership/index.ts
+++ b/src/ridership/index.ts
@@ -39,3 +39,17 @@ export {
   type LineMetrics,
   type LineMetricsInput,
 } from './lineMetrics';
+
+/**
+ * A Line joined to the figures this Month Window derives about it.
+ *
+ * The join lives here rather than in `buildRidershipView` because that module
+ * deliberately never receives a full `Line` — it takes `LineSelection` and returns
+ * maps keyed by line id, which is what keeps the write-back cycle structurally out
+ * of it. Assembling the readout is the caller's step.
+ */
+export {
+  buildLineReadouts,
+  type LineReadout,
+  type LineReadoutsInput,
+} from './lineReadouts';

--- a/src/ridership/lineReadouts.test.ts
+++ b/src/ridership/lineReadouts.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { buildLineReadouts } from './lineReadouts';
+import type { LineMetrics } from './lineMetrics';
+import type { LineCoverage } from './chartData';
+import { makeLine } from '../test/builders';
+
+const metrics801: LineMetrics = {
+  averageRidership: 1000,
+  changeInRidership: 200,
+  startingRidership: 900,
+  endingRidership: 1100,
+  ridersPerMile: 50,
+};
+
+const coverage801: LineCoverage = {
+  coveredFrom: '2022-01',
+  coveredTo: '2022-06',
+  isPartialCoverage: true,
+};
+
+describe('buildLineReadouts', () => {
+  it('carries all five figures for a line present in metrics', () => {
+    const [readout] = buildLineReadouts({
+      lines: [makeLine({ id: 801 })],
+      metrics: { 801: metrics801 },
+      coverage: {},
+    });
+
+    expect(readout.averageRidership).toBe(1000);
+    expect(readout.changeInRidership).toBe(200);
+    expect(readout.startingRidership).toBe(900);
+    expect(readout.endingRidership).toBe(1100);
+    expect(readout.ridersPerMile).toBe(50);
+  });
+
+  it("keeps the line's own fields alongside its figures", () => {
+    const [readout] = buildLineReadouts({
+      lines: [makeLine({ id: 801, name: 'A Line', selected: true })],
+      metrics: { 801: metrics801 },
+      coverage: {},
+    });
+
+    expect(readout.id).toBe(801);
+    expect(readout.name).toBe('A Line');
+    expect(readout.mode).toBe('Rail');
+    expect(readout.selected).toBe(true);
+  });
+
+  it('carries the covered span for a line present in coverage', () => {
+    const [readout] = buildLineReadouts({
+      lines: [makeLine({ id: 801 })],
+      metrics: {},
+      coverage: { 801: coverage801 },
+    });
+
+    expect(readout.coveredFrom).toBe('2022-01');
+    expect(readout.coveredTo).toBe('2022-06');
+    expect(readout.isPartialCoverage).toBe(true);
+  });
+
+  it('writes no figure keys at all for a line in neither map', () => {
+    // Presence, not value: spreading `undefined` writes no keys, which is what makes
+    // a figure from a previous Month Window structurally impossible to survive.
+    const [readout] = buildLineReadouts({
+      lines: [makeLine({ id: 801 })],
+      metrics: {},
+      coverage: {},
+    });
+
+    expect('averageRidership' in readout).toBe(false);
+    expect('changeInRidership' in readout).toBe(false);
+    expect('startingRidership' in readout).toBe(false);
+    expect('endingRidership' in readout).toBe(false);
+    expect('ridersPerMile' in readout).toBe(false);
+    expect('coveredFrom' in readout).toBe(false);
+    expect('coveredTo' in readout).toBe(false);
+    expect('isPartialCoverage' in readout).toBe(false);
+  });
+
+  it('writes a ridersPerMile key of undefined when the metrics say so', () => {
+    // `LineMetrics.ridersPerMile` is `number | undefined`, never optional: the key is
+    // always written, so a line that lost its distance reads as `undefined` rather
+    // than as absent.
+    const [readout] = buildLineReadouts({
+      lines: [makeLine({ id: 801 })],
+      metrics: { 801: { ...metrics801, ridersPerMile: undefined } },
+      coverage: {},
+    });
+
+    expect('ridersPerMile' in readout).toBe(true);
+    expect(readout.ridersPerMile).toBeUndefined();
+  });
+
+  it('joins metrics and coverage onto the same readout', () => {
+    const [readout] = buildLineReadouts({
+      lines: [makeLine({ id: 801 })],
+      metrics: { 801: metrics801 },
+      coverage: { 801: coverage801 },
+    });
+
+    expect(readout.averageRidership).toBe(1000);
+    expect(readout.coveredTo).toBe('2022-06');
+  });
+
+  it('follows the order of lines, not the key order of metrics', () => {
+    const readouts = buildLineReadouts({
+      lines: [
+        makeLine({ id: 801, name: 'A Line' }),
+        makeLine({ id: 802, name: 'B Line' }),
+        makeLine({ id: 2, name: 'Line 2', mode: 'Bus' }),
+      ],
+      metrics: {
+        2: { ...metrics801, averageRidership: 2 },
+        802: { ...metrics801, averageRidership: 802 },
+        801: { ...metrics801, averageRidership: 801 },
+      },
+      coverage: {},
+    });
+
+    expect(readouts.map((readout) => readout.id)).toEqual([801, 802, 2]);
+    expect(readouts.map((readout) => readout.averageRidership)).toEqual([
+      801, 802, 2,
+    ]);
+  });
+
+  it('returns an empty array for no lines', () => {
+    expect(
+      buildLineReadouts({
+        lines: [],
+        metrics: { 801: metrics801 },
+        coverage: { 801: coverage801 },
+      }),
+    ).toEqual([]);
+  });
+
+  it('ignores metrics and coverage for lines that are not present', () => {
+    const readouts = buildLineReadouts({
+      lines: [makeLine({ id: 801 })],
+      metrics: { 802: metrics801 },
+      coverage: { 802: coverage801 },
+    });
+
+    expect(readouts).toHaveLength(1);
+    expect('averageRidership' in readouts[0]).toBe(false);
+  });
+
+  it('does not mutate the input lines array or its elements', () => {
+    const line = makeLine({ id: 801 });
+    const lines = [line];
+    const snapshot = { ...line };
+
+    const readouts = buildLineReadouts({
+      lines,
+      metrics: { 801: metrics801 },
+      coverage: { 801: coverage801 },
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(line).toEqual(snapshot);
+    expect(readouts[0]).not.toBe(line);
+  });
+});

--- a/src/ridership/lineReadouts.ts
+++ b/src/ridership/lineReadouts.ts
@@ -1,0 +1,40 @@
+import type { Line } from '../@types/lines.types';
+import type { LineMetrics } from './lineMetrics';
+import type { LineCoverage } from './chartData';
+
+/**
+ * A Line together with everything the current Ridership View derives about it —
+ * its Line Metrics and the span its records cover.
+ *
+ * Derived per Month Window and thrown away. A `Line` never carries figures between
+ * windows, which is why a stale figure cannot survive a change of window; the
+ * clearing branch this replaced existed only because it could.
+ */
+export type LineReadout = Line & Partial<LineMetrics> & Partial<LineCoverage>;
+
+export interface LineReadoutsInput {
+  lines: readonly Line[];
+  metrics: Readonly<Record<number, LineMetrics>>;
+  coverage: Readonly<Record<number, LineCoverage>>;
+}
+
+/**
+ * Attach each Line's derived figures to it.
+ *
+ * A Line absent from `metrics` — no records in the Month Window — simply gets no
+ * figures: spreading `undefined` writes no keys. There is nothing to clear.
+ *
+ * Order is preserved, so readouts follow `lines`, which is alphabetical by line
+ * name. Legend, dataset and table order all continue to follow that one array.
+ */
+export function buildLineReadouts({
+  lines,
+  metrics,
+  coverage,
+}: LineReadoutsInput): LineReadout[] {
+  return lines.map((line) => ({
+    ...line,
+    ...metrics[line.id],
+    ...coverage[line.id],
+  }));
+}

--- a/src/utils/lines.test.ts
+++ b/src/utils/lines.test.ts
@@ -4,8 +4,10 @@ import {
   getLineNames,
   lineNameSortFunction,
   generateCSV,
+  listedReadouts,
 } from './lines';
 import type { ConsolidatedRidership } from '../@types/metrics.types';
+import type { LineReadout } from '../ridership';
 import {
   makeConsolidatedRidership,
   makeLine,
@@ -214,5 +216,202 @@ describe('generateCSV', () => {
     const csv = decodeURI(generateCSV({}));
     const lines = csv.split('\r\n').filter(Boolean);
     expect(lines).toHaveLength(1); // just the header line
+  });
+});
+
+describe('listedReadouts', () => {
+  const figures = {
+    averageRidership: 1000,
+    changeInRidership: 200,
+    startingRidership: 900,
+    endingRidership: 1100,
+    ridersPerMile: 50,
+  };
+
+  const railWithFigures: LineReadout = {
+    ...makeLine({ id: 801, name: 'A Line', mode: 'Rail' }),
+    ...figures,
+  };
+
+  const busWithFigures: LineReadout = {
+    ...makeLine({ id: 2, name: 'Line 2', mode: 'Bus' }),
+    ...figures,
+  };
+
+  const bothModes = ['bus', 'train'];
+
+  it('drops a Bus line when modes excludes "bus"', () => {
+    const listed = listedReadouts({
+      readouts: [busWithFigures, railWithFigures],
+      searchText: '',
+      modes: ['train'],
+    });
+
+    expect(listed.map((readout) => readout.id)).toEqual([801]);
+  });
+
+  it('drops a Rail line when modes excludes "train"', () => {
+    const listed = listedReadouts({
+      readouts: [busWithFigures, railWithFigures],
+      searchText: '',
+      modes: ['bus'],
+    });
+
+    expect(listed.map((readout) => readout.id)).toEqual([2]);
+  });
+
+  it('lists both modes when both are switched on', () => {
+    const listed = listedReadouts({
+      readouts: [busWithFigures, railWithFigures],
+      searchText: '',
+      modes: bothModes,
+    });
+
+    expect(listed.map((readout) => readout.id)).toEqual([2, 801]);
+  });
+
+  it('lists nothing when no mode is switched on', () => {
+    expect(
+      listedReadouts({
+        readouts: [busWithFigures, railWithFigures],
+        searchText: '',
+        modes: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it('changes the listed set when modes changes', () => {
+    const readouts = [busWithFigures, railWithFigures];
+
+    expect(
+      listedReadouts({ readouts, searchText: '', modes: bothModes }),
+    ).toHaveLength(2);
+    expect(
+      listedReadouts({ readouts, searchText: '', modes: ['train'] }),
+    ).toHaveLength(1);
+  });
+
+  it('lists a line whose change is exactly 0', () => {
+    // `lineMetrics` yields changeInRidership 0 for a single record, so a truthy
+    // check emptied the whole table for any single-month window (PR #93).
+    const zeroChange: LineReadout = {
+      ...railWithFigures,
+      changeInRidership: 0,
+    };
+
+    expect(
+      listedReadouts({
+        readouts: [zeroChange],
+        searchText: '',
+        modes: bothModes,
+      }),
+    ).toHaveLength(1);
+  });
+
+  it('lists a line whose average ridership is 0', () => {
+    const zeroAverage: LineReadout = {
+      ...railWithFigures,
+      averageRidership: 0,
+    };
+
+    expect(
+      listedReadouts({
+        readouts: [zeroAverage],
+        searchText: '',
+        modes: bothModes,
+      }),
+    ).toHaveLength(1);
+  });
+
+  it('does not list a line with no figures at all', () => {
+    // A line with no records in the Month Window gets no figure keys, so it is
+    // absent from the table rather than shown with blanks.
+    const noFigures: LineReadout = makeLine({ id: 801, mode: 'Rail' });
+
+    expect(
+      listedReadouts({
+        readouts: [noFigures],
+        searchText: '',
+        modes: bothModes,
+      }),
+    ).toEqual([]);
+  });
+
+  it('does not list a line carrying only an average', () => {
+    const halfFigures: LineReadout = {
+      ...makeLine({ id: 801, mode: 'Rail' }),
+      averageRidership: 1000,
+    };
+
+    expect(
+      listedReadouts({
+        readouts: [halfFigures],
+        searchText: '',
+        modes: bothModes,
+      }),
+    ).toEqual([]);
+  });
+
+  it('does not list a line whose mode is switched off even with figures', () => {
+    expect(
+      listedReadouts({
+        readouts: [railWithFigures],
+        searchText: '',
+        modes: ['bus'],
+      }),
+    ).toEqual([]);
+  });
+
+  it('matches the search text case-insensitively', () => {
+    expect(
+      listedReadouts({
+        readouts: [busWithFigures, railWithFigures],
+        searchText: 'a lIne',
+        modes: bothModes,
+      }).map((readout) => readout.id),
+    ).toEqual([801]);
+  });
+
+  it('lists nothing when the search text matches no name', () => {
+    expect(
+      listedReadouts({
+        readouts: [busWithFigures, railWithFigures],
+        searchText: 'zzz',
+        modes: bothModes,
+      }),
+    ).toEqual([]);
+  });
+
+  it('filters nothing on an empty search text', () => {
+    expect(
+      listedReadouts({
+        readouts: [busWithFigures, railWithFigures],
+        searchText: '',
+        modes: bothModes,
+      }),
+    ).toHaveLength(2);
+  });
+
+  it('preserves the order of readouts', () => {
+    const other: LineReadout = {
+      ...makeLine({ id: 10, name: 'Line 10', mode: 'Bus' }),
+      ...figures,
+    };
+    const listed = listedReadouts({
+      readouts: [railWithFigures, other, busWithFigures],
+      searchText: '',
+      modes: bothModes,
+    });
+
+    expect(listed.map((readout) => readout.id)).toEqual([801, 10, 2]);
+  });
+
+  it('does not mutate the readouts it is given', () => {
+    const readouts = [busWithFigures, railWithFigures];
+    const snapshot = readouts.map((readout) => ({ ...readout }));
+
+    listedReadouts({ readouts, searchText: 'a line', modes: ['train'] });
+
+    expect(readouts).toEqual(snapshot);
   });
 });

--- a/src/utils/lines.ts
+++ b/src/utils/lines.ts
@@ -1,5 +1,8 @@
 import type { Line } from '../@types/lines.types';
 import type { ConsolidatedRidership } from '../@types/metrics.types';
+// Type-only, so this leaves no runtime edge back into `src/ridership` — which
+// imports this module for line names and colors.
+import type { LineReadout } from '../ridership';
 
 const definedLines = [
   {
@@ -104,6 +107,46 @@ export const lineNameSortFunction = (a: Line, b: Line) => {
   // Names must be equal
   return 0;
 };
+
+export interface ListedReadoutsInput {
+  readouts: readonly LineReadout[];
+  searchText: string;
+  modes: readonly string[];
+}
+
+/**
+ * The Line Readouts the line table shows.
+ *
+ * Three clauses, all of which must hold: the line's mode is switched on, its name
+ * matches the search text, and it has figures for this Month Window. That last one
+ * is why a line with no records in the window is absent from the table rather than
+ * shown with blanks.
+ *
+ * Presence checks, not truthiness: `changeInRidership` is legitimately exactly `0`
+ * for a single-record line, so a truthy test dropped every line from the table
+ * whenever the window narrowed to one month (PR #93).
+ *
+ * The map and the summary panel are **not** filtered this way — they read every
+ * Line Readout and select on the user's own selection.
+ */
+export function listedReadouts({
+  readouts,
+  searchText,
+  modes,
+}: ListedReadoutsInput): LineReadout[] {
+  const busVisible = modes.includes('bus');
+  const trainVisible = modes.includes('train');
+  const search = searchText.toLocaleLowerCase();
+
+  return readouts.filter((readout) => {
+    if (readout.mode === 'Bus' ? !busVisible : !trainVisible) return false;
+    if (search && !readout.name.toLocaleLowerCase().includes(search)) return false;
+    return (
+      readout.averageRidership !== undefined &&
+      readout.changeInRidership !== undefined
+    );
+  });
+}
 
 /**
  * From https://stackoverflow.com/a/14966131.


### PR DESCRIPTION
Closes #133. **Slice 4 of 6** under #129. Purely additive — two new modules, green and unconsumed. Nothing imports either yet, so the built bundle is byte-identical to `main` (same content hashes: `index-9ZABZt9A.js`, `OutputArea-BSAzwRfU.js`).

## What lands

**`src/ridership/lineReadouts.ts`** (new) — `buildLineReadouts` joins each `Line` to the figures the current Ridership View derives about it.

- `LineReadout = Line & Partial<LineMetrics> & Partial<LineCoverage>` — a type alias intersection, not a restatement of nine optional fields. An alias cannot drift from `LineMetrics`; a restatement can.
- A Line absent from `metrics` gets **no figure keys at all**. Spreading `undefined` writes no keys, which is what makes a stale figure from a previous Month Window structurally impossible. Asserted with `'averageRidership' in readout === false`, not `=== undefined` — only the first proves it.
- Order follows `lines`, not the key order of `metrics` (ADR-0001). Covered by a test whose `metrics` keys are deliberately out of order.

**`src/utils/lines.ts`** — `listedReadouts` lifts the hook's `isVisibleLine` (`useUserDashboardInput.ts:244-268`) into a pure function over the three inputs it actually depends on. Options object in, filtered array out — not a per-item predicate.

- Mode clause replaces `line.visible`, preserving `createLinesData:71-73`.
- Search clause unchanged, `toLocaleLowerCase` on both sides.
- **Presence checks, not truthiness** — `changeInRidership` is legitimately exactly `0` for a single-record line; a truthy test emptied the whole table for a one-month window (PR #93).
- **No `Number.isNaN` clause.** `lineMetrics` returns `null` for an empty series (ADR-0004); #139 deleted the survivor. Not reintroduced.

`src/ridership/index.ts` gains `buildLineReadouts` / `type LineReadout` / `type LineReadoutsInput`. Every existing export is untouched — `buildCoverageByLine` in particular **stays exported**, since the hook imports it until slice 6.

Tests build on `src/test/builders.ts`; no new factories.

## Verify gate

- `npm run lint && npm test && npm run build` → green. **465 tests, 19 files.**
- `npx vitest run src/ridership/lineReadouts.test.ts src/utils/lines.test.ts` → 52 passed.
- `npm run test:e2e` → failures, **all pre-existing on `origin/main`**. Control run at `46867c0` with the diff removed fails too (8 there, 18 on the branch; overlapping sets, plus `page.goto` timeouts — flaky local run against gitignored per-developer `-win32.png` scratch). No committed Linux baseline was touched and no baseline was regenerated. The decisive evidence is the bundle hashes above: the shipped app is byte-identical, so no rendered behaviour can have drifted.

## Defaults taken

- **The mode ternary is the plan's verbatim form** — `readout.mode === 'Bus' ? !busVisible : !trainVisible`. A mode that is neither `'Bus'` nor `'Rail'` would follow `trainVisible` rather than being dropped outright, which differs from `createLinesData:71-73`'s explicit `false`. It is unrepresentable: `Line.mode` is typed `'Bus' | 'Rail'`, and the plan (step 13) justifies the verbatim form on exactly that ground. A three-branch version would narrow its own else to `never`. Flagged rather than silently widened.
- **`src/utils/lines.ts` imports `LineReadout` type-only** from `../ridership`. `src/ridership/buildRidershipView.ts` already imports this module for names and colors, so a value import would close a runtime cycle; `import type` is erased and leaves no edge.
- Two cases beyond the plan's list: `ridersPerMile` written as an `undefined` *key* (it is `number | undefined`, never optional, so it must stay present), and a readout carrying only an average is not listed (both presence clauses must hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Independent review

**PASS**, no findings — full verdict from a blind reviewer subagent (fresh context, `opus`, briefed on #133 + the spec + ADRs only) is posted verbatim as a PR comment: https://github.com/streetsforall/metro_ridership_app/pull/151#issuecomment-5242628052

Nothing to fix, so no re-run and no issue filed. The reviewer's one closing note — the mode ternary treating a non-`Bus` mode as Rail — is the same point already recorded under **Defaults taken** above, reached independently; it judges the verbatim form spec-conformant (`derived-figures-off-line-state.md:539-543`) and does not raise it as a finding.
