### PR TITLE
feat(month): add `src/utils/month.ts` and its test

### DIFF
--- a/src/utils/month.test.ts
+++ b/src/utils/month.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ordinal,
+  monthOf,
+  monthsEqual,
+  compareMonths,
+  parseMonth,
+  formatMonth,
+  displayMonth,
+  contains,
+  containsOffset,
+  type Month,
+  type MonthWindow,
+} from './month';
+
+/** The window ADR-0001's boundary cases are stated against. */
+const window2020: MonthWindow = {
+  start: { year: 2020, month: 1 },
+  end: { year: 2020, month: 12 },
+};
+
+describe('ordinal', () => {
+  it('is 1-based month minus one, plus twelve per year', () => {
+    expect(ordinal({ year: 2020, month: 1 })).toBe(2020 * 12);
+    expect(ordinal({ year: 2020, month: 12 })).toBe(2020 * 12 + 11);
+  });
+
+  it('advances by one across a year boundary', () => {
+    expect(ordinal({ year: 2021, month: 1 }) - ordinal({ year: 2020, month: 12 })).toBe(1);
+  });
+});
+
+describe('containsOffset — the Month Window rule, S <= R <= E - 2', () => {
+  it('includes the start month', () => {
+    expect(containsOffset(window2020, { year: 2020, month: 1 })).toBe(true);
+  });
+
+  it('excludes one month before the start', () => {
+    expect(containsOffset(window2020, { year: 2019, month: 12 })).toBe(false);
+  });
+
+  it('includes E - 2', () => {
+    expect(containsOffset(window2020, { year: 2020, month: 10 })).toBe(true);
+  });
+
+  it('excludes E - 1', () => {
+    expect(containsOffset(window2020, { year: 2020, month: 11 })).toBe(false);
+  });
+
+  it('excludes the end month', () => {
+    expect(containsOffset(window2020, { year: 2020, month: 12 })).toBe(false);
+  });
+
+  // Exercises the *12 term: the window and its boundaries straddle a year boundary.
+  describe('across a year boundary', () => {
+    const crossing: MonthWindow = {
+      start: { year: 2019, month: 11 },
+      end: { year: 2020, month: 2 },
+    };
+
+    it('includes the start month and E - 2', () => {
+      expect(containsOffset(crossing, { year: 2019, month: 11 })).toBe(true);
+      expect(containsOffset(crossing, { year: 2019, month: 12 })).toBe(true);
+    });
+
+    it('excludes E - 1 and E', () => {
+      expect(containsOffset(crossing, { year: 2020, month: 1 })).toBe(false);
+      expect(containsOffset(crossing, { year: 2020, month: 2 })).toBe(false);
+    });
+  });
+});
+
+describe('contains — the Event Window rule, inclusive on both ends', () => {
+  it('includes the start month', () => {
+    expect(contains(window2020, { year: 2020, month: 1 })).toBe(true);
+  });
+
+  it('includes the end month', () => {
+    expect(contains(window2020, { year: 2020, month: 12 })).toBe(true);
+  });
+
+  it('excludes one month before the start', () => {
+    expect(contains(window2020, { year: 2019, month: 12 })).toBe(false);
+  });
+
+  it('excludes one month after the end', () => {
+    expect(contains(window2020, { year: 2021, month: 1 })).toBe(false);
+  });
+
+  // The two rules read the same window and genuinely disagree about it. That is
+  // deliberate — see ADR-0001. This test is the guard against a future tidy-up that
+  // "unifies" them; if it fails, one of the two rules has drifted.
+  it('disagrees with containsOffset at the end of the window', () => {
+    const endMonth: Month = { year: 2020, month: 12 };
+    expect(contains(window2020, endMonth)).toBe(true);
+    expect(containsOffset(window2020, endMonth)).toBe(false);
+  });
+});
+
+describe('monthOf', () => {
+  it('leaves an in-range month alone', () => {
+    expect(monthOf(2025, 9)).toEqual({ year: 2025, month: 9 });
+  });
+
+  it('rolls 13 forward into the next January', () => {
+    expect(monthOf(2025, 13)).toEqual({ year: 2026, month: 1 });
+  });
+
+  it('rolls 0 back into the previous December', () => {
+    expect(monthOf(2025, 0)).toEqual({ year: 2024, month: 12 });
+  });
+
+  // Pins the ((o % 12) + 12) % 12 guard: a plain % would yield a negative month here.
+  it('rolls a negative month back into the previous November', () => {
+    expect(monthOf(2025, -1)).toEqual({ year: 2024, month: 11 });
+  });
+});
+
+describe('monthsEqual', () => {
+  it('compares by value, not identity', () => {
+    expect(monthsEqual({ year: 2025, month: 9 }, { year: 2025, month: 9 })).toBe(true);
+  });
+
+  it('is false when the month differs', () => {
+    expect(monthsEqual({ year: 2025, month: 9 }, { year: 2025, month: 10 })).toBe(false);
+  });
+
+  it('is false when the year differs', () => {
+    expect(monthsEqual({ year: 2025, month: 9 }, { year: 2024, month: 9 })).toBe(false);
+  });
+});
+
+describe('compareMonths', () => {
+  // A lexicographic sort on "YYYY M" gets this wrong — "2025 10" < "2025 7" as text.
+  // This is why buildMonthAxis sorts on an ordinal.
+  it('sorts chronologically, not lexicographically', () => {
+    const months: Month[] = [
+      { year: 2025, month: 10 },
+      { year: 2025, month: 7 },
+      { year: 2024, month: 12 },
+    ];
+    expect([...months].sort(compareMonths)).toEqual([
+      { year: 2024, month: 12 },
+      { year: 2025, month: 7 },
+      { year: 2025, month: 10 },
+    ]);
+  });
+
+  it('is zero for equal months', () => {
+    expect(compareMonths({ year: 2025, month: 9 }, { year: 2025, month: 9 })).toBe(0);
+  });
+});
+
+describe('parseMonth', () => {
+  it('parses a valid YYYY-MM string to a Month', () => {
+    expect(parseMonth('2020-07')).toEqual({ year: 2020, month: 7 });
+  });
+
+  it('zero-pads single-digit months correctly', () => {
+    expect(parseMonth('2022-01')).toEqual({ year: 2022, month: 1 });
+  });
+
+  it('parses December correctly', () => {
+    expect(parseMonth('2025-12')).toEqual({ year: 2025, month: 12 });
+  });
+
+  it('returns null for a non-numeric string', () => {
+    expect(parseMonth('invalid')).toBeNull();
+  });
+
+  it('returns null for nonsense', () => {
+    expect(parseMonth('nonsense')).toBeNull();
+  });
+
+  it('returns null when month is 0', () => {
+    expect(parseMonth('2020-00')).toBeNull();
+    expect(parseMonth('2025-00')).toBeNull();
+  });
+
+  it('returns null when month exceeds 12', () => {
+    expect(parseMonth('2020-13')).toBeNull();
+    expect(parseMonth('2025-13')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseMonth('')).toBeNull();
+  });
+});
+
+describe('formatMonth', () => {
+  it('formats a Month to YYYY-MM with zero-padded month', () => {
+    expect(formatMonth({ year: 2020, month: 7 })).toBe('2020-07');
+  });
+
+  it('zero-pads January', () => {
+    expect(formatMonth({ year: 2022, month: 1 })).toBe('2022-01');
+  });
+
+  it('formats December without padding', () => {
+    expect(formatMonth({ year: 2025, month: 12 })).toBe('2025-12');
+  });
+});
+
+describe('parseMonth / formatMonth round-trip', () => {
+  // Every shared URL depends on this holding.
+  it.each(['2019-12', '2026-05', '2009-01'])('round-trips %s', (text) => {
+    expect(formatMonth(parseMonth(text)!)).toBe(text);
+  });
+});
+
+describe('displayMonth', () => {
+  it('renders a Month for humans', () => {
+    expect(displayMonth({ year: 2025, month: 9 })).toBe('Sep 2025');
+  });
+});

--- a/src/utils/month.ts
+++ b/src/utils/month.ts
@@ -1,0 +1,110 @@
+/**
+ * A month, and the two rules for whether one falls inside a Month Window.
+ *
+ * A month is a year and a 1-based month number — not a `Date`. A `Date` is a
+ * timestamp: it carries a day, an hour and a timezone that a month does not have, its
+ * month is 0-based where every other month in this system is 1-based, and its two
+ * constructors disagree about which month it is (`new Date("2025-09")` is UTC midnight,
+ * which is August in Los Angeles). See
+ * `docs/adr/0006-a-month-is-a-year-and-a-month-not-a-date.md`.
+ */
+
+export interface Month {
+  year: number;
+  /** 1-based: January is 1, matching the data, the URL and `transit-events.json`. */
+  month: number;
+}
+
+export interface MonthWindow {
+  start: Month;
+  end: Month;
+}
+
+/**
+ * Months since year 0. The single arithmetic form; every comparison goes through it.
+ */
+export const ordinal = (m: Month): number => m.year * 12 + (m.month - 1);
+
+/**
+ * Build a Month, normalising out-of-range month numbers rather than rejecting them:
+ * `monthOf(2025, 13)` is January 2026. Total — it never throws, so there is no crash
+ * path to guard.
+ *
+ * It does not make an invalid Month unrepresentable. `{year: 2025, month: 13}` is a
+ * legal literal, because `Month` is structural on purpose (a `RidershipRecord` is one).
+ * That is an accepted limitation: such a value sorts and compares as January 2026
+ * rather than corrupting anything. Untrusted input goes through `parseMonth`, which
+ * rejects instead.
+ */
+export function monthOf(year: number, month: number): Month {
+  const o = year * 12 + (month - 1);
+  return { year: Math.floor(o / 12), month: (((o % 12) + 12) % 12) + 1 };
+}
+
+export const monthsEqual = (a: Month, b: Month): boolean =>
+  a.year === b.year && a.month === b.month;
+
+/** Sort comparator. Chronological. */
+export const compareMonths = (a: Month, b: Month): number => ordinal(a) - ordinal(b);
+
+/**
+ * Parse the canonical text form, `"YYYY-MM"` — the format of the `start`/`end` URL
+ * params, of `transit-events.json` dates, and of the coverage labels. `null` for
+ * anything malformed; this is the untrusted edge.
+ */
+export function parseMonth(text: string): Month | null {
+  const [yearStr, monthStr] = text.split('-');
+  const year = parseInt(yearStr, 10);
+  const month = parseInt(monthStr, 10);
+  if (isNaN(year) || isNaN(month) || month < 1 || month > 12) return null;
+  return { year, month };
+}
+
+/** The inverse of `parseMonth`: `"2025-09"`, zero-padded. */
+export const formatMonth = (m: Month): string =>
+  `${m.year}-${String(m.month).padStart(2, '0')}`;
+
+/**
+ * For humans: `"Sep 2025"`.
+ *
+ * The **one** place in the app that constructs a `Date`, because `toLocaleString` needs
+ * one. It is local and immediately discarded, so none of `Date`'s hazards escape this
+ * function. Do not add a second.
+ */
+export const displayMonth = (m: Month): string =>
+  new Date(m.year, m.month - 1).toLocaleString('en-US', {
+    month: 'short',
+    year: 'numeric',
+  });
+
+/**
+ * Is `m` inside the window, **inclusive of both ends**?
+ *
+ * This is the **Event Window** rule (`CONTEXT.md`). It deliberately disagrees with
+ * `containsOffset` below, which applies to the same window. Reconciling them would
+ * change which events appear for a given URL — see ADR-0001.
+ */
+export function contains(w: MonthWindow, m: Month): boolean {
+  const r = ordinal(m);
+  return r >= ordinal(w.start) && r <= ordinal(w.end);
+}
+
+/**
+ * Is `m` inside the window under the **Month Window** rule — `S <= R <= E - 2`?
+ *
+ * The start month is included; the end month **and the month immediately before it**
+ * are excluded. This reads like a bug and is not: it is the behaviour the app has
+ * always had, users have shared URLs against it, and `e2e/chart-content.spec.ts`
+ * renders windows through it into committed PNG baselines. See
+ * `docs/adr/0001-ridership-month-window-is-deliberately-offset.md`.
+ *
+ * Derived from the `Date` comparison it replaces. With bounds built as
+ * `new Date(y, m - 1)` and records as `new Date(r.year, r.month)`, the strict
+ * comparison `start < record < end` is `S < R + 1 < E`, i.e. `S <= R <= E - 2`. The
+ * boundary tests in `month.test.ts`, not this derivation, are what make that safe;
+ * ADR-0006 carries the working.
+ */
+export function containsOffset(w: MonthWindow, m: Month): boolean {
+  const r = ordinal(m);
+  return r >= ordinal(w.start) && r <= ordinal(w.end) - 2;
+}


### PR DESCRIPTION
**G1 of 5** under umbrella #142 (candidate 4, "one representation of a month"). Closes #143.

**Purely additive.** One module and its test. Nothing imports it — this is verified:

```bash
grep -rn "from '.*utils/month'" src/ | grep -v month.test
```

Returns nothing.

Landing the value type and both containment rules alone means any failure here is the *rule* being wrong, not the wiring. Every later slice (G2–G5) is a conversion; this is the only one with new logic in it.

## What lands

`Month` (`{year, month}`, **1-based**), `MonthWindow` (`{start, end}`), and `ordinal`, `monthOf`, `monthsEqual`, `compareMonths`, `parseMonth`, `formatMonth`, `displayMonth`, `contains`, `containsOffset`. Verbatim from `src/plans/one-representation-of-a-month.md` step 1.

The two rules read the same window and **genuinely disagree** about it, which is deliberate and pinned by ADR-0001:

- `contains` — the Event Window rule. Inclusive on both ends.
- `containsOffset` — the Month Window rule, `S ≤ R ≤ E − 2`. Start month in; the end month **and the month immediately before it** out. Derived in the module doc comment from the `Date` comparison G2 will replace.

One test — `disagrees with containsOffset at the end of the window` — asserts both functions on `2020-12` and gets opposite answers. That test is the guard against a future tidy-up that "unifies" them.

## Test coverage worth a reviewer's eye

- All five ADR-0001 boundary cases for `containsOffset`: start in, one month earlier out, `E − 2` in, `E − 1` out, `E` out — plus a year-crossing window (`2019-11` → `2020-02`) so the `*12` term is exercised.
- `monthOf` normalises rather than throwing: `(2025, 13)` → `{2026, 1}`, `(2025, 0)` → `{2024, 12}`, `(2025, -1)` → `{2024, 11}` (the last pins the `((o % 12) + 12) % 12` guard).
- `parseMonth` **rejects** rather than normalising — the untrusted edge. `'2025-13'`, `'2025-00'`, `'nonsense'`, `''` all `null`, matching `parseMonthParam`'s current behaviour exactly.
- Round-trip `formatMonth(parseMonth(s)!) === s`. The month cases from `queryParams.test.ts` are **ported**, including `zero-pads single-digit months correctly`. Every shared URL keeps working.
- `compareMonths` sorts `2024-12, 2025-7, 2025-10` — the case a lexicographic sort on `"YYYY M"` gets wrong, and the reason `buildMonthAxis` sorts on an ordinal today.

## Scope

`src/utils/queryParams.ts` and its test are **untouched** — that file is candidate 5's territory. Test cases were ported, not moved; the deletion happens in G3. No existing file is modified, not even an index. No `Month` builder added to `src/test/builders.ts` — `{year: 2025, month: 9}` is shorter than any call that would build it.

## Verification

`npm run lint && npm test && npm run build` → green. 478 tests, 19 files. `npx vitest run src/utils/month.test.ts` → 38 passed.

`npm run test:e2e` was run even though the plan does not require it for this slice. **No committed Linux baseline changed** — nothing rendered changes, since the module is unreferenced. The local run showed 3 failures against **gitignored per-developer `-win32.png` scratch baselines**; the same suite on unmodified `origin/main` (`46867c0`) fails 4, a superset of the same mobile `chart-content` tests. Pre-existing local flake, not drift from this diff. `test:e2e:update` / `test:e2e:update:linux` were **not** run.

## Defaults taken

None beyond what the plan already settles. Two choices worth naming because they look like omissions:

- **`Month` is structural, not branded.** `{year: 2025, month: 13}` type-checks. That cost is accepted and stated in the module doc comment and ADR-0006, and it is the point: a `RidershipRecord` *is* a `Month`, so G2 passes records straight into `containsOffset` with no conversion.
- **`ordinal` is exported**, per the plan — `month.test.ts` asserts on it directly and G4 uses it as a `Map` key.


## Independent review

An independent reviewer, given the spec and the ADRs but not my reasoning, reviewed `46867c0...origin/refactor/add-month-module` at `b6caa34`. **Verdict: PASS, no findings.** It posted its full verdict as a PR comment — that comment, not this summary, is the record; read it there rather than trusting a paraphrase.

Nothing required a fix, so the verify gate above stands as run.

It raised **one observation it explicitly classified as not a finding and requested no change for**, recorded here so it does not vanish:

> The negative-`monthOf` test comment claims it pins the `((o % 12) + 12) % 12` guard. It doesn't: with `year = 2025`, `o = 24298` is positive, so plain `o % 12` already gives `10` and the `+12` is a no-op. The guard is load-bearing only for `year <= 0`, unreachable here. Behaviour asserted is correct and the wording came from the plan and #143 verbatim, so leave it — flagged only so nobody over-trusts that comment as coverage.

**Not acted on, deliberately.** The reviewer is right on the arithmetic, and the point is worth knowing. But the asserted behaviour — `monthOf(2025, -1)` is `{2024, 11}` — is correct and is what #143 and the plan demand pinned; only the comment's *explanation* of which branch it exercises is loose. The wording is the spec's own, verbatim, and the spec is read-only for this slice. Changing it here would put this PR's test comment out of step with the plan text that G2–G5 are also written against, for no change in coverage. No issue filed, because the reviewer requested no change and there is no defect to track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
