### PR TITLE
refactor(lines): delete the line-metrics write-back (#135)

### DIFF
--- a/src/@types/lines.types.ts
+++ b/src/@types/lines.types.ts
@@ -11,20 +11,5 @@ export interface Line {
   mode: 'Bus' | 'Rail';
   provider: 'DO' | 'PT';
   selected: boolean;
-  visible: boolean;
-  averageRidership?: number;
-  changeInRidership?: number;
-  startingRidership?: number;
-  endingRidership?: number;
   distanceMiles?: number;
-  ridersPerMile?: number;
-  /**
-   * The span this line's own records cover inside the selected window, as `YYYY-MM`.
-   * The summary metrics are estimated from these endpoints rather than from the
-   * window's, so the table shows the range each row's figures actually describe.
-   */
-  coveredFrom?: string;
-  coveredTo?: string;
-  /** True when this line covers less of the window than the window's full span. */
-  isPartialCoverage?: boolean;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,6 @@ function App() {
     setDayOfWeek,
     endDate,
     setEndDate,
-    updateLinesWithLineMetrics,
     searchText,
     modes,
     isAggregateVisible,
@@ -71,8 +70,8 @@ function App() {
    * deliberately offset month window, the shared axis, the aggregate ordering)
    * lives in src/ridership/ and is unit-tested there.
    *
-   * Kept memoised: the metrics effect below keys on JSON.stringify(consolidated), and
-   * a fresh object every render would thrash it.
+   * Kept memoised: `metrics` and `coverage` feed the readouts below, whose own memo
+   * keys on their identity, so a fresh view every render would thrash it.
    */
   const { months, datasets, consolidated, events, metrics, coverage } = useMemo(
     () =>
@@ -91,9 +90,9 @@ function App() {
    * Each Line with the figures this window derives for it. Rebuilt whole whenever
    * the view changes, so a figure from a previous window cannot survive.
    *
-   * No JSON.stringify in the dependency array: `metrics` and `coverage` come out of
-   * the already-memoised `buildRidershipView` above, so their identity is stable per
-   * view.
+   * Nothing is stringified into the dependency array: `metrics` and `coverage` come
+   * out of the already-memoised `buildRidershipView` above, so their identity is
+   * stable per view.
    */
   const readouts = useMemo(
     () => buildLineReadouts({ lines, metrics, coverage }),
@@ -104,16 +103,6 @@ function App() {
     () => listedReadouts({ readouts, searchText, modes }),
     [readouts, searchText, modes],
   );
-
-  /**
-   * Attach computed metrics (average ridership, change, etc.) to each line entry
-   * so the LineSelector can display them. JSON.stringify is used as the dependency
-   * because consolidated is a new object reference on every render (useMemo).
-   */
-  useEffect(() => {
-    updateLinesWithLineMetrics(consolidated);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(consolidated)]);
 
   return (
     /* Stretch full height */

--- a/src/components/LineFilters.test.tsx
+++ b/src/components/LineFilters.test.tsx
@@ -8,7 +8,7 @@ const defaultProps = {
   modes: ['bus', 'train'],
   setModes: vi.fn(),
   clearSelections: vi.fn(),
-  selectAllVisibleLines: vi.fn(),
+  selectAllListedLines: vi.fn(),
   isAggregateVisible: false,
   toggleIsAggregateVisible: vi.fn(),
 };
@@ -78,16 +78,16 @@ describe('LineFilters interactions', () => {
     expect(setSearchText).toHaveBeenCalledWith('blue');
   });
 
-  it('calls selectAllVisibleLines when Select All is clicked', () => {
-    const selectAllVisibleLines = vi.fn();
+  it('calls selectAllListedLines when Select All is clicked', () => {
+    const selectAllListedLines = vi.fn();
     render(
       <LineFilters
         {...defaultProps}
-        selectAllVisibleLines={selectAllVisibleLines}
+        selectAllListedLines={selectAllListedLines}
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: 'Select All' }));
-    expect(selectAllVisibleLines).toHaveBeenCalledOnce();
+    expect(selectAllListedLines).toHaveBeenCalledOnce();
   });
 
   it('calls clearSelections when Clear All is clicked', () => {
@@ -116,15 +116,15 @@ describe('LineFilters interactions', () => {
     expect(clearSelections).not.toHaveBeenCalled();
   });
 
-  it('does not call selectAllVisibleLines when Clear All is clicked', () => {
-    const selectAllVisibleLines = vi.fn();
+  it('does not call selectAllListedLines when Clear All is clicked', () => {
+    const selectAllListedLines = vi.fn();
     render(
       <LineFilters
         {...defaultProps}
-        selectAllVisibleLines={selectAllVisibleLines}
+        selectAllListedLines={selectAllListedLines}
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: 'Clear All' }));
-    expect(selectAllVisibleLines).not.toHaveBeenCalled();
+    expect(selectAllListedLines).not.toHaveBeenCalled();
   });
 });

--- a/src/components/LineFilters.tsx
+++ b/src/components/LineFilters.tsx
@@ -11,7 +11,7 @@ interface LineFiltersProps {
   modes: string[];
   setModes: React.Dispatch<React.SetStateAction<string[]>>;
   clearSelections: () => void;
-  selectAllVisibleLines: () => void;
+  selectAllListedLines: () => void;
   isAggregateVisible: boolean;
   toggleIsAggregateVisible: () => void;
 }
@@ -22,7 +22,7 @@ export default function LineFilters({
   modes,
   setModes,
   clearSelections,
-  selectAllVisibleLines,
+  selectAllListedLines,
   isAggregateVisible,
   toggleIsAggregateVisible,
 }: LineFiltersProps) {
@@ -77,7 +77,7 @@ export default function LineFilters({
           <button
             id="select-all"
             type="button"
-            onClick={selectAllVisibleLines}
+            onClick={selectAllListedLines}
             className="bg-transparent border-none p-0 font-bold text-xs text-[#0fada8]"
           >
             Select All

--- a/src/components/LineSelector.test.tsx
+++ b/src/components/LineSelector.test.tsx
@@ -24,7 +24,7 @@ const defaultProps = {
   modes: ['bus', 'train'],
   setModes: vi.fn(),
   clearSelections: vi.fn(),
-  selectAllVisibleLines: vi.fn(),
+  selectAllListedLines: vi.fn(),
   isAggregateVisible: false,
   toggleIsAggregateVisible: vi.fn(),
 };

--- a/src/components/LineSelector.tsx
+++ b/src/components/LineSelector.tsx
@@ -152,7 +152,7 @@ interface LineSelectorProps {
   modes: string[];
   setModes: React.Dispatch<React.SetStateAction<string[]>>;
   clearSelections: () => void;
-  selectAllVisibleLines: () => void;
+  selectAllListedLines: (ids: number[]) => void;
   isAggregateVisible: boolean;
   toggleIsAggregateVisible: () => void;
 }
@@ -173,7 +173,7 @@ export default function LineSelector(props: LineSelectorProps) {
     modes,
     setModes,
     clearSelections,
-    selectAllVisibleLines,
+    selectAllListedLines,
     isAggregateVisible,
     toggleIsAggregateVisible,
   } = props;
@@ -275,9 +275,7 @@ export default function LineSelector(props: LineSelectorProps) {
 
     // Sort lines
     return lodash.orderBy(lines, sortKeys, sortDirections);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(columnHeaderStates), JSON.stringify(lines), dayOfWeek]);
+  }, [columnHeaderStates, lines]);
 
   const shareData: ShareData = {
     title: 'LA Metro Ridership Data',
@@ -329,7 +327,9 @@ export default function LineSelector(props: LineSelectorProps) {
         modes={modes}
         setModes={setModes}
         clearSelections={clearSelections}
-        selectAllVisibleLines={selectAllVisibleLines}
+        selectAllListedLines={(): void =>
+          selectAllListedLines(sortedLines.map((l) => l.id))
+        }
         isAggregateVisible={isAggregateVisible}
         toggleIsAggregateVisible={toggleIsAggregateVisible}
       />

--- a/src/hooks/useUserDashboardInput.test.ts
+++ b/src/hooks/useUserDashboardInput.test.ts
@@ -3,11 +3,6 @@ import { renderHook, act } from '@testing-library/react';
 import useUserDashboardInput, { daysOfWeek } from './useUserDashboardInput';
 import { dataDefaultEndDate } from '../utils/dataDateRange';
 import { formatMonthParam } from '../utils/queryParams';
-import type { ConsolidatedRidership } from '../@types/metrics.types';
-import {
-  makeConsolidatedRidership,
-  makeRidershipRecord,
-} from '../test/builders';
 
 // Reset URL and replaceState spy before each test
 beforeEach(() => {
@@ -137,42 +132,39 @@ describe('initial state from URL params', () => {
   });
 });
 
-describe('modes → line visibility', () => {
-  it('hides bus lines when buses=0 is in URL', () => {
+describe('modes → mode filter state', () => {
+  /**
+   * These asserted on `Line.visible` until the write-back went. The mode clause now
+   * lives in `listedReadouts`, which is tested in `src/utils/lines.test.ts`; what is
+   * left here is the hook's own half — the URL contract onto `modes`.
+   */
+  it('switches bus off when buses=0 is in URL', () => {
     window.history.replaceState({}, '', '?buses=0');
     const { result } = renderHook(() => useUserDashboardInput());
-    const busLines = result.current.lines.filter((l) => l.mode === 'Bus');
-    expect(busLines.length).toBeGreaterThan(0);
-    expect(busLines.every((l) => !l.visible)).toBe(true);
+    expect(result.current.modes).not.toContain('bus');
   });
 
-  it('keeps rail lines visible when only buses=0', () => {
+  it('leaves train on when only buses=0', () => {
     window.history.replaceState({}, '', '?buses=0');
     const { result } = renderHook(() => useUserDashboardInput());
-    const railLines = result.current.lines.filter((l) => l.mode === 'Rail');
-    expect(railLines.every((l) => l.visible)).toBe(true);
+    expect(result.current.modes).toContain('train');
   });
 
-  it('hides rail lines when trains=0 is in URL', () => {
+  it('switches train off when trains=0 is in URL', () => {
     window.history.replaceState({}, '', '?trains=0');
     const { result } = renderHook(() => useUserDashboardInput());
-    const railLines = result.current.lines.filter((l) => l.mode === 'Rail');
-    expect(railLines.length).toBeGreaterThan(0);
-    expect(railLines.every((l) => !l.visible)).toBe(true);
+    expect(result.current.modes).not.toContain('train');
   });
 
-  it('updates visibility when modes state changes', () => {
+  it('updates the mode filter when modes state changes', () => {
     const { result } = renderHook(() => useUserDashboardInput());
 
     act(() => {
       result.current.setModes(['train']);
     });
 
-    const busLines = result.current.lines.filter((l) => l.mode === 'Bus');
-    expect(busLines.every((l) => !l.visible)).toBe(true);
-
-    const railLines = result.current.lines.filter((l) => l.mode === 'Rail');
-    expect(railLines.every((l) => l.visible)).toBe(true);
+    expect(result.current.modes).not.toContain('bus');
+    expect(result.current.modes).toContain('train');
   });
 });
 
@@ -320,246 +312,38 @@ describe('line initialisation', () => {
   });
 });
 
-describe('updateLinesWithLineMetrics', () => {
-  const makeRidership = (
-    lineId: number,
-    wkday: number,
-  ): ConsolidatedRidership =>
-    makeConsolidatedRidership(
-      lineId,
-      [
-        makeRidershipRecord({
-          line_name: lineId,
-          est_wkday_ridership: wkday,
-          est_sat_ridership: null,
-          est_sun_ridership: null,
-        }),
-      ],
-      { selected: true },
-    );
-
-  it('sets ridersPerMile on a line that has distanceMiles', () => {
+describe('selectAllListedLines', () => {
+  it('selects a listed line', () => {
+    // Was `selectAllVisibleLines selects a zero-change line too`: the hook no longer
+    // re-derives which rows are listed, so the ids are passed in. That a zero-change
+    // line is among them is `listedReadouts`' assertion now.
     const { result } = renderHook(() => useUserDashboardInput());
 
     act(() => {
-      result.current.updateLinesWithLineMetrics(makeRidership(801, 10000));
-    });
-
-    const aLine = result.current.lines.find((l) => l.id === 801);
-    expect(aLine?.ridersPerMile).toBeGreaterThan(0);
-  });
-
-  it('computes ridersPerMile as averageRidership divided by distanceMiles', () => {
-    const { result } = renderHook(() => useUserDashboardInput());
-
-    act(() => {
-      result.current.updateLinesWithLineMetrics(makeRidership(801, 10000));
-    });
-
-    const aLine = result.current.lines.find((l) => l.id === 801);
-    expect(aLine?.ridersPerMile).toBeCloseTo(
-      10000 / (aLine?.distanceMiles ?? 1),
-      5,
-    );
-  });
-
-  it('leaves ridersPerMile undefined when no ridership record exists for the line', () => {
-    const { result } = renderHook(() => useUserDashboardInput());
-
-    act(() => {
-      result.current.updateLinesWithLineMetrics({});
-    });
-
-    const aLine = result.current.lines.find((l) => l.id === 801);
-    expect(aLine?.ridersPerMile).toBeUndefined();
-  });
-
-  it('clears every derived metric when a line drops out of the window', () => {
-    // The no-record branch used to clear only averageRidership and changeInRidership,
-    // leaving the previous window's starting/ending/riders-per-mile on the row.
-    const { result } = renderHook(() => useUserDashboardInput());
-
-    act(() => {
-      result.current.updateLinesWithLineMetrics(makeRidership(801, 10000));
-    });
-
-    const populated = result.current.lines.find((l) => l.id === 801);
-    expect(populated?.startingRidership).toBe(10000);
-    expect(populated?.endingRidership).toBe(10000);
-    expect(populated?.ridersPerMile).toBeGreaterThan(0);
-    expect(populated?.coveredFrom).toBe('2022-01');
-
-    act(() => {
-      result.current.updateLinesWithLineMetrics({});
-    });
-
-    const cleared = result.current.lines.find((l) => l.id === 801);
-    expect(cleared?.averageRidership).toBeUndefined();
-    expect(cleared?.changeInRidership).toBeUndefined();
-    expect(cleared?.startingRidership).toBeUndefined();
-    expect(cleared?.endingRidership).toBeUndefined();
-    expect(cleared?.ridersPerMile).toBeUndefined();
-    expect(cleared?.coveredFrom).toBeUndefined();
-    expect(cleared?.coveredTo).toBeUndefined();
-    expect(cleared?.isPartialCoverage).toBeUndefined();
-  });
-});
-
-describe('coverage metadata on lines', () => {
-  const makeRecord = (lineId: number, year: number, month: number) =>
-    makeRidershipRecord({
-      year,
-      month,
-      line_name: lineId,
-      est_wkday_ridership: 5000,
-      est_sat_ridership: null,
-      est_sun_ridership: null,
-    });
-
-  // 801 spans the window, 805 only its tail — the D Line shape from #86.
-  const mixedCoverage: ConsolidatedRidership = {
-    ...makeConsolidatedRidership(
-      801,
-      [makeRecord(801, 2025, 7), makeRecord(801, 2025, 8), makeRecord(801, 2025, 9)],
-      { selected: true },
-    ),
-    ...makeConsolidatedRidership(805, [makeRecord(805, 2025, 9)], {
-      selected: true,
-    }),
-  };
-
-  it('flags the short-coverage line and records its range', () => {
-    const { result } = renderHook(() => useUserDashboardInput());
-
-    act(() => {
-      result.current.updateLinesWithLineMetrics(mixedCoverage);
-    });
-
-    const dLine = result.current.lines.find((l) => l.id === 805);
-    expect(dLine?.isPartialCoverage).toBe(true);
-    expect(dLine?.coveredFrom).toBe('2025-09');
-    expect(dLine?.coveredTo).toBe('2025-09');
-  });
-
-  it('does not flag a line that spans the whole window', () => {
-    const { result } = renderHook(() => useUserDashboardInput());
-
-    act(() => {
-      result.current.updateLinesWithLineMetrics(mixedCoverage);
-    });
-
-    const aLine = result.current.lines.find((l) => l.id === 801);
-    expect(aLine?.isPartialCoverage).toBe(false);
-    expect(aLine?.coveredFrom).toBe('2025-07');
-    expect(aLine?.coveredTo).toBe('2025-09');
-  });
-
-  it('does not reorder the records it was handed', () => {
-    // The metric functions used to sort ridershipRecords in place — the same array
-    // the sparklines and the CSV export read. `lineMetrics` sorts a copy.
-    const unsorted: ConsolidatedRidership = makeConsolidatedRidership(
-      801,
-      [makeRecord(801, 2025, 9), makeRecord(801, 2025, 7), makeRecord(801, 2025, 8)],
-      { selected: true },
-    );
-
-    const { result } = renderHook(() => useUserDashboardInput());
-
-    act(() => {
-      result.current.updateLinesWithLineMetrics(unsorted);
-    });
-
-    expect(unsorted[801].ridershipRecords.map((r) => r.month)).toEqual([9, 7, 8]);
-  });
-});
-
-describe('line visibility', () => {
-  const singleMonth = (lineId: number, wkday: number): ConsolidatedRidership =>
-    makeConsolidatedRidership(lineId, [
-      makeRidershipRecord({
-        year: 2026,
-        month: 3,
-        line_name: lineId,
-        est_wkday_ridership: wkday,
-        est_sat_ridership: null,
-        est_sun_ridership: null,
-      }),
-    ]);
-
-  it('keeps a line whose change is exactly 0 in the table', () => {
-    // `lineMetrics` returns changeInRidership 0 for a single record, so the old
-    // truthiness check emptied the whole table for any single-month window.
-    const { result } = renderHook(() => useUserDashboardInput());
-
-    act(() => {
-      result.current.updateLinesWithLineMetrics(singleMonth(801, 10000));
-    });
-
-    const aLine = result.current.lines.find((l) => l.id === 801);
-    expect(aLine?.changeInRidership).toBe(0);
-    expect(result.current.visibleLines.some((l) => l.id === 801)).toBe(true);
-  });
-
-  it('keeps a line whose average ridership is 0 in the table', () => {
-    const { result } = renderHook(() => useUserDashboardInput());
-
-    act(() => {
-      result.current.updateLinesWithLineMetrics(singleMonth(801, 0));
-    });
-
-    expect(result.current.visibleLines.some((l) => l.id === 801)).toBe(true);
-  });
-
-  it('selectAllVisibleLines selects a zero-change line too', () => {
-    const { result } = renderHook(() => useUserDashboardInput());
-
-    act(() => {
-      result.current.updateLinesWithLineMetrics(singleMonth(801, 10000));
-    });
-
-    act(() => {
-      result.current.selectAllVisibleLines();
+      result.current.selectAllListedLines([801]);
     });
 
     expect(result.current.lines.find((l) => l.id === 801)?.selected).toBe(true);
   });
 
-  it('excludes a line with no metrics at all', () => {
+  it('leaves a line that was not listed unselected', () => {
     const { result } = renderHook(() => useUserDashboardInput());
 
     act(() => {
-      result.current.updateLinesWithLineMetrics({});
+      result.current.selectAllListedLines([801]);
     });
 
-    expect(result.current.visibleLines).toHaveLength(0);
+    expect(result.current.lines.find((l) => l.id === 802)?.selected).toBe(false);
   });
 
-  it('excludes a line with an empty record set', () => {
-    // `lineMetrics` returns null for an empty series, so the derived fields are
-    // cleared to undefined. The module this replaced divided by the record count and
-    // put a NaN there instead; either way no metric reaches the table and the row is
-    // hidden. The row staying hidden is the assertion that matters here.
+  it('keeps an already-selected line selected when it is not listed', () => {
+    window.history.replaceState({}, '', '?lines=802');
     const { result } = renderHook(() => useUserDashboardInput());
 
     act(() => {
-      result.current.updateLinesWithLineMetrics({
-        801: { selected: false, ridershipRecords: [] },
-      });
+      result.current.selectAllListedLines([801]);
     });
 
-    const aLine = result.current.lines.find((l) => l.id === 801);
-    expect(aLine?.averageRidership).toBeUndefined();
-    expect(result.current.visibleLines.some((l) => l.id === 801)).toBe(false);
-  });
-
-  it('excludes a hidden line even when it has metrics', () => {
-    window.history.replaceState({}, '', '?trains=0');
-    const { result } = renderHook(() => useUserDashboardInput());
-
-    act(() => {
-      result.current.updateLinesWithLineMetrics(singleMonth(801, 10000));
-    });
-
-    expect(result.current.visibleLines.some((l) => l.id === 801)).toBe(false);
+    expect(result.current.lines.find((l) => l.id === 802)?.selected).toBe(true);
   });
 });

--- a/src/hooks/useUserDashboardInput.ts
+++ b/src/hooks/useUserDashboardInput.ts
@@ -1,5 +1,4 @@
-import { useMemo, useState, useEffect } from 'react';
-import { buildCoverageByLine, lineMetrics } from '../ridership';
+import { useState, useEffect } from 'react';
 import { getLineNames, lineNameSortFunction } from '../utils/lines';
 import {
   parseMonthParam,
@@ -9,12 +8,7 @@ import {
   parseModesFromParams,
 } from '../utils/queryParams';
 import type { Line, LineJson } from '../@types/lines.types';
-import {
-  daysOfWeek,
-  type DayOfWeek,
-  type ConsolidatedRecord,
-  type ConsolidatedRidership,
-} from '../@types/metrics.types';
+import { daysOfWeek, type DayOfWeek } from '../@types/metrics.types';
 
 export { daysOfWeek, type DayOfWeek };
 import LineJsonData from '../data/metro_line_metadata_current.json';
@@ -40,8 +34,6 @@ export interface UserDashboardInputState {
   modes: string[];
   setModes: React.Dispatch<React.SetStateAction<string[]>>;
 
-  visibleLines: Line[];
-
   isAggregateVisible: boolean;
   toggleIsAggregateVisible: () => void;
 
@@ -50,8 +42,7 @@ export interface UserDashboardInputState {
 
   onToggleSelectLine: (line: Line) => void;
   clearSelections: () => void;
-  updateLinesWithLineMetrics: (ridershipByLine: ConsolidatedRidership) => void;
-  selectAllVisibleLines: () => void;
+  selectAllListedLines: (ids: number[]) => void;
 }
 
 
@@ -61,23 +52,15 @@ export interface UserDashboardInputState {
 const DefaultStartDate: Date = new Date(2020, 6);
 const DefaultEndDate: Date = dataDefaultEndDate;
 
-const createLinesData = (selectedLineIds: number[], modes: string[]): Line[] => {
-  const busVis = modes.includes('bus');
-  const trainVis = modes.includes('train');
-
+const createLinesData = (selectedLineIds: number[]): Line[] => {
   return (LineJsonData as LineJson[])
     .map((line: LineJson) => {
-      let visible = false;
-      if (line.mode === 'Bus') visible = busVis;
-      else if (line.mode === 'Rail') visible = trainVis;
-
       return {
         ...line,
         id: line.line,
         name: getLineNames(line.line).current,
         former: getLineNames(line.line).former,
         selected: selectedLineIds.includes(line.line),
-        visible,
         distanceMiles: (LineDistances as Record<string, number>)[String(line.line)],
       } as Line;
     })
@@ -118,7 +101,7 @@ const useUserDashboardInput = (): UserDashboardInputState => {
     const selectedIds = linesStr
       ? linesStr.split(',').map(Number).filter((id) => !isNaN(id))
       : [];
-    return createLinesData(selectedIds, parseModesFromParams(params));
+    return createLinesData(selectedIds);
   });
 
   const [isAggregateVisible, setIsAggregateVisible] = useState<boolean>(() => {
@@ -130,21 +113,6 @@ const useUserDashboardInput = (): UserDashboardInputState => {
     const params = new URLSearchParams(window.location.search);
     return params.get('logs') === '1';
   });
-
-  // Sync modes → line visibility
-  useEffect(() => {
-    const busVis = modes.includes('bus');
-    const trainVis = modes.includes('train');
-
-    setLines((prevLines) =>
-      prevLines.map((prevLine) => {
-        let visible = false;
-        if (prevLine.mode === 'Bus') visible = busVis;
-        else if (prevLine.mode === 'Rail') visible = trainVis;
-        return { ...prevLine, visible };
-      }),
-    );
-  }, [modes]);
 
   // Sync state → URL query params
   useEffect(() => {
@@ -164,114 +132,21 @@ const useUserDashboardInput = (): UserDashboardInputState => {
     if (showContextLogs) params.set('logs', '1');
 
     window.history.replaceState(null, '', `?${params.toString()}`);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [startDate, endDate, dayOfWeek, searchText, modes, JSON.stringify(lines), isAggregateVisible, showContextLogs]);
+  }, [startDate, endDate, dayOfWeek, searchText, modes, lines, isAggregateVisible, showContextLogs]);
 
   /**
-   * Use the aggregated metrics to add additional metrics to line metadata
-   * @param ridershipByLine
+   * Select every row the table is currently showing, on top of whatever is already
+   * selected. The hook cannot re-derive which rows those are — the rule needs Line
+   * Readouts, which live in App — so it takes the displayed ids instead.
    */
-  const updateLinesWithLineMetrics = (
-    ridershipByLine: ConsolidatedRidership,
-  ): void => {
-    /**
-     * Which slice of the window each line actually reports. Lines no longer all cover
-     * the same span — the D Line's data starts 2025-09 while most rail reaches back to
-     * 2009 — so the metrics below, which read each line's own first and last record,
-     * measure different periods per row. Stamping the covered range onto the line lets
-     * the table say so instead of implying a uniform period.
-     */
-    const coverageByLine = buildCoverageByLine(ridershipByLine);
-
-    setLines((prevLines: Line[]): Line[] =>
-      prevLines.map((prevLine: Line) => {
-        const updatedLine: Line = { ...prevLine };
-
-        // Check if ridership metrics exist for line
-        const consolidatedRecord: ConsolidatedRecord | undefined =
-          ridershipByLine[updatedLine.id];
-
-        if (!consolidatedRecord) {
-          // Clear every derived field, not just the two the table filters on —
-          // otherwise a line with no records in the new window keeps rendering the
-          // previous window's starting/ending/riders-per-mile figures.
-          updatedLine.averageRidership = undefined;
-          updatedLine.changeInRidership = undefined;
-          updatedLine.startingRidership = undefined;
-          updatedLine.endingRidership = undefined;
-          updatedLine.ridersPerMile = undefined;
-          updatedLine.coveredFrom = undefined;
-          updatedLine.coveredTo = undefined;
-          updatedLine.isPartialCoverage = undefined;
-
-          return updatedLine;
-        }
-
-        const metrics = lineMetrics({
-          records: consolidatedRecord.ridershipRecords,
-          dayOfWeek,
-          distanceMiles: updatedLine.distanceMiles,
-        });
-
-        const coverage = coverageByLine[updatedLine.id];
-
-        return {
-          ...updatedLine,
-          ...(metrics ?? {
-            averageRidership: undefined,
-            changeInRidership: undefined,
-            startingRidership: undefined,
-            endingRidership: undefined,
-            ridersPerMile: undefined,
-          }),
-          coveredFrom: coverage?.coveredFrom,
-          coveredTo: coverage?.coveredTo,
-          isPartialCoverage: coverage?.isPartialCoverage,
-        };
-      }),
+  const selectAllListedLines = (ids: number[]): void => {
+    const listed = new Set(ids);
+    setLines((prevLines) =>
+      prevLines.map((prevLine) => ({
+        ...prevLine,
+        selected: listed.has(prevLine.id) || prevLine.selected,
+      })),
     );
-  };
-
-  const isVisibleLine = (line: Line): boolean => {
-    if (searchText) {
-      const searchTextLower = searchText.toLocaleLowerCase();
-      const visible: boolean = line.name
-        .toLocaleLowerCase()
-        .includes(searchTextLower);
-
-      if (!visible) {
-        return false;
-      }
-    }
-
-    /**
-     * Presence checks, not truthiness: `changeInRidership` is exactly 0 for a line
-     * with a single record, so a truthy test dropped every line from the table
-     * whenever the window narrowed to one month. There is no NaN case to exclude:
-     * `lineMetrics` returns null for an empty series, so the fields are cleared to
-     * undefined rather than carrying a sentinel.
-     */
-    return (
-      line.visible &&
-      line.averageRidership !== undefined &&
-      line.changeInRidership !== undefined
-    );
-  };
-
-  const visibleLines = useMemo(
-    () => lines.filter(isVisibleLine),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(lines), searchText],
-  );
-
-  const selectAllVisibleLines = (): void => {
-    setLines((prevLines: Line[]) => {
-      return prevLines.map((prevLine: Line) => {
-        const isLineVisible: boolean = isVisibleLine(prevLine);
-
-        return { ...prevLine, selected: isLineVisible || prevLine.selected };
-      });
-    });
   };
 
   const onToggleSelectLine = (line: Line): void => {
@@ -317,7 +192,6 @@ const useUserDashboardInput = (): UserDashboardInputState => {
     setDayOfWeek,
     lines,
     setLines,
-    visibleLines,
     isAggregateVisible,
     toggleIsAggregateVisible,
     showContextLogs,
@@ -328,8 +202,7 @@ const useUserDashboardInput = (): UserDashboardInputState => {
     setModes,
     onToggleSelectLine,
     clearSelections,
-    updateLinesWithLineMetrics,
-    selectAllVisibleLines,
+    selectAllListedLines,
   };
 };
 

--- a/src/ridership/index.ts
+++ b/src/ridership/index.ts
@@ -25,7 +25,6 @@ export {
  */
 export {
   alignToMonthAxis,
-  buildCoverageByLine,
   buildWindowMonthAxis,
   type LineCoverage,
 } from './chartData';

--- a/src/test/builders.ts
+++ b/src/test/builders.ts
@@ -39,7 +39,6 @@ export const makeLine = (overrides: Partial<Line> = {}): Line => ({
   mode: 'Rail',
   provider: 'DO',
   selected: false,
-  visible: true,
   ...overrides,
 });
 


### PR DESCRIPTION
Closes #135. **PR 6 of 6** for #129. Deletions plus one signature change; nothing new is written.

## What changed

- **`updateLinesWithLineMetrics` and its `App.tsx` effect are gone.** Every figure the table, summary panel and map render already comes from the Line Readouts #154 introduced, so the round trip through `Line` state had no remaining reader. `buildCoverageByLine` lost its last caller and leaves `src/ridership/index.ts`; `chartData.ts` is untouched and its tests keep importing it directly from `./chartData`.
- **`isVisibleLine`, `visibleLines` and the `modes → line visibility` effect are gone.** The rule lives in `listedReadouts`. `createLinesData` stops computing `visible` and no longer takes `modes`, so `lines` changes identity only on real user actions — which is why the URL-sync effect can key on `lines` directly and drop its `exhaustive-deps` disable.
- **`selectAllVisibleLines()` → `selectAllListedLines(ids)`.** The hook cannot re-derive which rows are listed (the rule needs readouts, which live in App), so `LineSelector` passes `sortedLines.map((l) => l.id)`. `LineSelector` never filters beyond what App gives it — it only sorts — so **the set it selects is unchanged**; only the meaning shifts, from "everything matching the predicate" to "everything currently listed".
- **`Line` is stripped** to `id`, `name`, `former?`, `mode`, `provider`, `selected`, `distanceMiles?` (ADR-0005). `makeLine` drops its `visible: true` default.
- **Hook tests: 61 → 44.** Per the plan's step-25 table. The `modes → line visibility` block is retargeted from the deleted `Line.visible` onto `result.current.modes` (its filtering half was ported to `listedReadouts` in slice 4); the `updateLinesWithLineMetrics`, `coverage metadata on lines` and `line visibility` blocks are deleted here, having been ported to `buildRidershipView.test.ts` and `lineReadouts.test.ts` in slices 3 and 4. The `selectAllVisibleLines` case survives as `selectAllListedLines` passing explicit ids, plus two new cases pinning the `listed.has(id) || prevLine.selected` semantics. **No assertion was weakened or relaxed.**

## The one intended behaviour change

The table currently shows the previous window's rows for a single commit while the effect round-trips. It no longer does. **Settled state is identical**, so no baseline moves — see the drift check below.

## Gate

`npm run lint && npm test && npm run build && npm run test:e2e` — all four green.

```
> eslint .          (clean)

 Test Files  20 passed (20)
      Tests  585 passed (585)

> tsc -b && vite build
✓ built in 6.99s

  7 skipped
  44 passed (1.1m)      # playwright
```

### How the e2e run was made a real drift check

Local `-win32.png` baselines are gitignored per-developer scratch and were stale/absent, so a plain run only proves the suite runs. Instead:

1. deleted every `*-win32.png`, stashed this branch's changes, and checked out the base commit `63b9b15`;
2. ran the suite twice there — the first run wrote fresh `-win32` baselines **from unmodified `63b9b15`**, the second confirmed that commit is green against them (`44 passed`);
3. restored this branch's changes and ran the suite again against those same base-commit baselines: **`44 passed, 7 skipped`, zero pixel diffs.**

So the rendered output is byte-identical to the base commit on this platform. `npm run test:e2e:update` / `:update:linux` were **not** run and no committed `-linux.png` was touched — CI's Linux e2e job remains the authoritative gate.

## Acceptance checks

```
$ grep -rn "updateLinesWithLineMetrics\|isVisibleLine\|visibleLines\|JSON.stringify(lines)\|line.visible" src/
src/plans/collapse-calc-into-line-metrics.md:7:  … (28 further hits, all in src/plans/*.md)
src/plans/derived-figures-off-line-state.md:5:
src/plans/one-representation-of-a-month.md:162:
src/plans/ridership-view-module.md:320:
```

Every remaining hit is prose in `src/plans/*.md` describing this work — including the grep command itself at `derived-figures-off-line-state.md:788`. The plans are out of fence for this slice and were not edited. Restricted to code, the check returns nothing:

```
$ grep -rn "updateLinesWithLineMetrics\|isVisibleLine\|visibleLines\|JSON.stringify(lines)\|line.visible" src/ --include=*.ts --include=*.tsx
$ echo $?
1
```

```
$ grep -rn "JSON.stringify" src/App.tsx src/hooks/useUserDashboardInput.ts src/components/LineSelector.tsx
$ echo $?
1
```

Nothing. All four arrays are gone. `LineTableRow.tsx:100`'s `JSON.stringify(ridershipRecords)` is a different array and survives untouched.

```
$ cat src/@types/lines.types.ts   # (Line only)
export interface Line {
  id: number;
  name: string;
  former?: string;
  mode: 'Bus' | 'Rail';
  provider: 'DO' | 'PT';
  selected: boolean;
  distanceMiles?: number;
}
```

## Defaults taken

- **`LineSelector`'s `sortedLines` memo dropped `JSON.stringify(columnHeaderStates)` / `JSON.stringify(lines)` for plain deps**, and dropped `dayOfWeek`, which the memo body never read. Required by the second acceptance grep. Both deps are now stable references (`columnHeaderStates` is state; `lines` is App's memoised `listed`), and `lodash.orderBy` is deterministic on its inputs, so this changes identity churn only, not output.
- **The `modes → line visibility` block was kept as four retargeted tests** rather than collapsed, even though two of them now overlap with the `initial state from URL params` block. Keeping each test's distinct intent visible was preferred to trimming the count.
- **`src/components/LineTableRow.tsx:97`'s comment** ("doesn't need the `JSON.stringify` treatment the others get") is now stale, since the others are gone. `LineTableRow.tsx` is outside this slice's fence, so it was left alone.
- **#153** (the `ridershipByLine` → Consolidated Ridership rename on `LineSelector`'s prop) was deliberately **not** absorbed; it reaches `chartData.ts` and `utils/lines.ts`, outside this fence.

## Merge authority

**I do not merge.** Michael merges every PR in this repo himself.
