### PR TITLE
fix: hide the output area when expanding, instead of unmounting it

### DIFF
--- a/e2e/loading.spec.ts
+++ b/e2e/loading.spec.ts
@@ -64,10 +64,14 @@ test('a failed ridership fetch does not crash the app', async ({ page }) => {
   );
 
   // Liveness, not just "something painted": React state still drives the tree. Expanding the
-  // line selector unmounts the output area (App.tsx renders it only when collapsed), and
+  // line selector hides the output area (App.tsx keeps it mounted and toggles `display`), and
   // collapsing brings it back. A crashed or wedged render fails one of these.
+  //
+  // Hidden, not absent: the node deliberately stays in the DOM so the Chart.js canvas and the
+  // MapLibre instance are not rebuilt on every collapse, so this asserts on visibility rather
+  // than on count.
   await page.locator('#expand-toggle').click();
-  await expect(page.locator('#output-placeholder')).toHaveCount(0);
+  await expect(page.locator('#output-placeholder')).toBeHidden();
   await page.locator('#expand-toggle').click();
   await expect(page.locator('#output-placeholder')).toBeVisible();
 

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -149,6 +149,43 @@ test('map — selecting a line updates the layer filter without a reload', async
 });
 
 /**
+ * Expanding the line selector hides the output area; it does not unmount it (App.tsx).
+ *
+ * Identity is checked by stamping the live map instance and reading the stamp back after the
+ * round trip: a torn-down-and-rebuilt map publishes a fresh `window.__metroMap` with no stamp,
+ * which is the regression this guards — a new MapLibre instance means a new WebGL context and
+ * the basemap style, glyphs and tiles fetched all over again on every collapse.
+ */
+test('map — survives a table-view round trip without re-initialising', async ({ page }) => {
+  await gotoMap(page, SELECTED_LINE_IDS);
+
+  await page.evaluate(() => {
+    (window.__metroMap as unknown as { __e2eStamp?: string }).__e2eStamp = 'original';
+  });
+
+  await page.locator('#expand-toggle').click();
+  await expect(page.locator('table thead')).toBeVisible();
+  // Hidden, but still in the DOM.
+  await expect(page.locator('#lineMap')).toBeHidden();
+
+  await page.locator('#expand-toggle').click();
+  await expect(page.locator('#lineMap')).toBeVisible();
+
+  expect(
+    await page.evaluate(
+      () => (window.__metroMap as unknown as { __e2eStamp?: string }).__e2eStamp,
+    ),
+  ).toBe('original');
+
+  // And it is still a working map after coming back from a zero-sized container: MapLibre's
+  // ResizeObserver re-measures on show, so the canvas has real dimensions and still draws.
+  await waitForMapIdle(page);
+  const selected = await renderedLineIds(page, 'lines-selected');
+  expect(selected.length).toBeGreaterThan(0);
+  expect(selected.filter((id) => !SELECTED_LINE_IDS.includes(id))).toEqual([]);
+});
+
+/**
  * `#lineMap` is a fixed `height: 400px; width: 100%` (src/components/Map.css), so narrowing the
  * viewport does not change the geometry the map draws — it changes the canvas aspect ratio, and
  * with it where MapLibre's NavigationControl and compact attribution control sit relative to the

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import App from './App';
 import type { ChartDataset } from 'chart.js';
 import type { CustomChartData } from './@types/chart.types';
@@ -60,7 +60,25 @@ vi.mock('./components/OutputArea', () => ({
 vi.mock('./components/Header', () => ({ default: () => <div /> }));
 vi.mock('./components/Footer', () => ({ default: () => <div /> }));
 vi.mock('./components/DateRangeSelector', () => ({ default: () => <div /> }));
-vi.mock('./components/LineSelector', () => ({ default: () => <div /> }));
+// Stands in for the expand toggle inside the real LineSelector, so the App-level
+// consequence of expanding (see the output-area test at the bottom) is reachable.
+vi.mock('./components/LineSelector', () => ({
+  default: ({
+    isExpanded,
+    setIsExpanded,
+  }: {
+    isExpanded: boolean;
+    setIsExpanded: (update: (prev: boolean) => boolean) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="expand-toggle"
+      onClick={() => setIsExpanded((prev) => !prev)}
+    >
+      {isExpanded ? 'collapse' : 'expand'}
+    </button>
+  ),
+}));
 
 beforeEach(() => {
   capturedDatasets = [];
@@ -175,6 +193,32 @@ describe('App - context log panel', () => {
     await waitForDatasets(1);
 
     expect(queryByTestId('context-log-panel')).toBeNull();
+  });
+});
+
+describe('App - expanded line selector', () => {
+  it('hides the output area rather than unmounting it', async () => {
+    window.history.replaceState({}, '', '?lines=807');
+
+    const { getByTestId } = render(<App />);
+    await waitForDatasets(1);
+
+    // The wrapper div App puts around OutputArea; Suspense contributes no DOM.
+    const output = getByTestId('output-area');
+    const wrapper = output.parentElement!;
+    expect(wrapper.className).toContain('contents');
+
+    fireEvent.click(getByTestId('expand-toggle'));
+
+    // Identity, not presence: the same DOM node means React kept the subtree mounted,
+    // so the Chart.js canvas and the MapLibre instance below it survive the expand.
+    expect(getByTestId('output-area')).toBe(output);
+    expect(wrapper.className).toContain('hidden');
+
+    fireEvent.click(getByTestId('expand-toggle'));
+
+    expect(getByTestId('output-area')).toBe(output);
+    expect(wrapper.className).toContain('contents');
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,10 +154,24 @@ function App() {
         </div>
 
         {/**
-         * Only show right side if line selector not selected
-         * TODO: Change this from conditional rendering to conditional visibility; that way it doesn't rerender every time
+         * The right side is hidden while the line selector is expanded, not unmounted.
+         *
+         * Unmounting it tore down the Chart.js canvas and the MapLibre instance, so every
+         * collapse paid for a fresh map — new WebGL context, basemap style and tiles fetched
+         * again — plus a chart rebuilt from scratch. Both are ready to draw already; the only
+         * thing that changed is whether they are on screen.
+         *
+         * `contents` on the wrapper makes OutputArea's own root the grid item, exactly as it
+         * was when this was conditionally rendered, so the visible layout is unchanged. When
+         * expanded the wrapper is `display: none`, which takes it out of the grid entirely —
+         * the `grid-cols-[1fr]` above then has a single column with a single item in it, as
+         * before.
+         *
+         * Coming back is safe without a manual re-measure: Chart.js's responsive mode and
+         * MapLibre's `trackResize` both watch their container with a ResizeObserver, which
+         * fires again when the box goes from zero back to its real size.
          */}
-        {!isLineSelectorExpanded && (
+        <div className={isLineSelectorExpanded ? 'hidden' : 'contents'}>
           <Suspense
             fallback={
               <div className="flex flex-col gap-4 lg:min-h-[50vh]">
@@ -176,7 +190,7 @@ function App() {
               isLoading={isLoading}
             />
           </Suspense>
-        )}
+        </div>
       </div>
 
       <Footer />


### PR DESCRIPTION
## What

`App.tsx` conditionally rendered the right-hand column away while the line selector was expanded (the `TODO` at the old L156–159). That unmounted `OutputArea`, taking the Chart.js canvas and the MapLibre instance with it — so every collapse rebuilt a map from scratch (new WebGL context, basemap style + tiles refetched) and redrew the chart, when the only thing that had changed was whether it was on screen.

Now it stays mounted and is hidden instead:

- wrapper is `contents` when visible → `OutputArea`'s own root is still the grid item, so the rendered layout is unchanged
- wrapper is `hidden` when expanded → `display: none` takes it out of the grid, leaving the same single-column table view as before
- coming back needs no manual re-measure: Chart.js's responsive mode and MapLibre's `trackResize` both observe their container with a `ResizeObserver`, which fires again when the box goes from zero back to real size

Lazy-loading is untouched — `OutputArea` is still `React.lazy`, and it already mounted on first paint (the selector starts collapsed), so the entry chunk is unaffected.

## Tests

- `src/App.test.tsx` — asserts the output-area DOM **node identity** survives an expand → collapse cycle (presence alone wouldn't distinguish a remount). The `LineSelector` mock now renders the expand toggle so the toggle is reachable from an App-level test.
- `e2e/map.spec.ts` — stamps the live `window.__metroMap`, does a table-view round trip, and reads the stamp back; a re-initialised map publishes a fresh instance with no stamp. Then re-queries rendered features, proving the map still draws after its container was zero-sized.

## Verification

- `npm run lint`, `tsc -b`, `npm test` (596) → green
- `visual.spec.ts` full-page baselines re-shot on `main` and re-run on this branch, `desktop` and `mobile` → **all 3 match on both**, including the expanded table view. So the layout is pixel-identical and masking `#lineMap` while it is hidden doesn't upset Playwright.
- `--project=map` → the new round-trip test passes. Two pre-existing local failures are unrelated: a missing `-win32` baseline and a stale `-win32` baseline, both of which fail on `main` too (CI compares only the `-linux` set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
