### PR TITLE
refactor(lines): rename the `ridershipByLine` prop to `consolidated` (#153)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,7 +136,7 @@ function App() {
           <LineSelector
             {...userDashboardInputState}
             lines={listed}
-            ridershipByLine={consolidated}
+            consolidated={consolidated}
             isExpanded={isLineSelectorExpanded}
             setIsExpanded={setIsLineSelectorExpanded}
           />

--- a/src/components/LineSelector.test.tsx
+++ b/src/components/LineSelector.test.tsx
@@ -12,7 +12,7 @@ vi.mock('react-chartjs-2', () => ({
 const mockLine: LineReadout = makeLineReadout();
 
 const defaultProps = {
-  ridershipByLine: {} as ConsolidatedRidership,
+  consolidated: {} as ConsolidatedRidership,
   lines: [] as LineReadout[],
   setLines: vi.fn(),
   onToggleSelectLine: vi.fn(),

--- a/src/components/LineSelector.tsx
+++ b/src/components/LineSelector.tsx
@@ -136,7 +136,7 @@ const toggleSortDirection = (sortDirection: SortDirection): SortDirection => {
 };
 
 interface LineSelectorProps {
-  ridershipByLine: ConsolidatedRidership;
+  consolidated: ConsolidatedRidership;
   lines: LineReadout[];
   /**
    * The Line state setter. Still `Line[]`: readouts are derived per Month Window
@@ -162,7 +162,7 @@ export default function LineSelector(props: LineSelectorProps) {
     useState<ColumnHeaderState[]>(columnStates);
   const [isCopied, setIsCopied] = useState(false);
   const {
-    ridershipByLine,
+    consolidated,
     lines,
     dayOfWeek,
     onToggleSelectLine,
@@ -185,8 +185,8 @@ export default function LineSelector(props: LineSelectorProps) {
    * scales differ.
    */
   const monthAxis: string[] = useMemo(
-    () => buildWindowMonthAxis(ridershipByLine),
-    [ridershipByLine],
+    () => buildWindowMonthAxis(consolidated),
+    [consolidated],
   );
 
   const onExpandClick = (): void => {
@@ -383,7 +383,7 @@ export default function LineSelector(props: LineSelectorProps) {
             <tbody>
               {sortedLines.map((line, id) => {
                 const consolidatedRecord: ConsolidatedRecord =
-                  ridershipByLine[line.id];
+                  consolidated[line.id];
 
                 return (
                   <LineTableRow
@@ -409,7 +409,7 @@ export default function LineSelector(props: LineSelectorProps) {
 
       <a
         id="download-csv"
-        href={generateCSV(ridershipByLine)}
+        href={generateCSV(consolidated)}
         download="metro_ridership.csv"
         className="button flex gap-2 items-center justify-center"
       >

--- a/src/ridership/chartData.ts
+++ b/src/ridership/chartData.ts
@@ -67,7 +67,7 @@ export function alignToMonthAxis(
 
 /**
  * The months that actually exist in the current window: the union across every line
- * in `ridershipByLine`.
+ * in `consolidated`.
  *
  * Deliberately derived from the records rather than from the selected
  * `startDate`/`endDate`. The Month Window `buildRidershipView` applies is offset on
@@ -81,10 +81,10 @@ export function alignToMonthAxis(
  * draws a row — and a coverage label — for lines the chart never plots.
  */
 export function buildWindowMonthAxis(
-  ridershipByLine: ConsolidatedRidership,
+  consolidated: ConsolidatedRidership,
 ): string[] {
   return buildMonthAxis(
-    Object.values(ridershipByLine).map((record) => record.ridershipRecords),
+    Object.values(consolidated).map((record) => record.ridershipRecords),
   );
 }
 
@@ -109,12 +109,12 @@ export interface LineCoverage {
  * that the UI stops implying they all mean the same period.
  */
 export function buildCoverageByLine(
-  ridershipByLine: ConsolidatedRidership,
+  consolidated: ConsolidatedRidership,
 ): Record<string, LineCoverage> {
-  const windowMonths = buildWindowMonthAxis(ridershipByLine);
+  const windowMonths = buildWindowMonthAxis(consolidated);
   const coverage: Record<string, LineCoverage> = {};
 
-  for (const [lineId, record] of Object.entries(ridershipByLine)) {
+  for (const [lineId, record] of Object.entries(consolidated)) {
     // Reusing buildMonthAxis for a single line dedupes and sorts it the same way the
     // window span was built, so the two are directly comparable.
     const months = buildMonthAxis([record.ridershipRecords]);

--- a/src/ridership/lineMetrics.test.ts
+++ b/src/ridership/lineMetrics.test.ts
@@ -224,9 +224,9 @@ describe('an empty series', () => {
 });
 
 describe('input is not mutated', () => {
-  // The array handed in is the live ridershipRecords array inside ridershipByLine,
-  // which also backs the row sparklines and the CSV export — sorting it in place
-  // reorders data other callers are reading.
+  // The array handed in is the live ridershipRecords array inside the Consolidated
+  // Ridership, which also backs the row sparklines and the CSV export — sorting it
+  // in place reorders data other callers are reading.
   const unsorted = () => [
     at(2022, 3, 1000),
     at(2022, 1, 2000),

--- a/src/utils/lines.ts
+++ b/src/utils/lines.ts
@@ -155,7 +155,7 @@ export function listedReadouts({
  * May return a NETWORK_INVALID_REQUEST.
  * Will need to have CSV export logic in a backend when that happens.
  */
-export const generateCSV = (ridershipByLine: ConsolidatedRidership): string => {
+export const generateCSV = (consolidated: ConsolidatedRidership): string => {
   let csvContent = 'data:text/csv;charset=utf-8,';
 
   // Add headers to CSV.
@@ -164,7 +164,7 @@ export const generateCSV = (ridershipByLine: ConsolidatedRidership): string => {
   csvContent += headers;
 
   // Get selected lines
-  const ridershipBySelectedLine = Object.values(ridershipByLine).filter(
+  const ridershipBySelectedLine = Object.values(consolidated).filter(
     (line) => line.selected,
   );
 


### PR DESCRIPTION
Closes #153.

## What

`CONTEXT.md:8-9` makes the glossary binding on naming — where a term conflicts with a name in the source, the term wins and the source is out of date. The **Consolidated Ridership** entry lists "ridership by line" under `_Avoid_`. `ridershipByLine` is that avoided synonym, and it sat on `LineSelector`'s **public interface**, not in a local.

`App.tsx` was the clearest tell: it already read the value as `consolidated` (renamed by #114/#119 — this same finding one level up) and handed it straight into a prop still called `ridershipByLine`.

Renamed to `consolidated`, matching `RidershipView.consolidated`:

- `src/components/LineSelector.tsx` — prop declaration, destructure, three reads
- `src/App.tsx` — now `consolidated={consolidated}`
- `src/components/LineSelector.test.tsx` — the fixture key
- `src/ridership/chartData.ts` — `buildWindowMonthAxis` / `buildCoverageByLine` parameters **and the docstring at `:70`**
- `src/utils/lines.ts` — `generateCSV`'s parameter
- `src/ridership/lineMetrics.test.ts` — a comment mentioning the old name

**This is a pure rename.** No behaviour change, no signature reordering, no type change, no logic touched. 6 files, 19 insertions, 19 deletions.

## Out of scope, deliberately

- `coverageByLine` and `ridershipBySelectedLine` (`src/utils/lines.ts:167`) — neither is a Consolidated Ridership, both untouched. `lines.ts:167` changes only because it *reads* the renamed parameter; the local binding keeps its name.
- `src/plans/*` — a historical record, excluded from the issue's acceptance grep. `CONTEXT.md`, `docs/adr/*`, `e2e/**` and every baseline PNG are untouched.

`src/ridership/chartData.ts` is renamed here even though #146 later rewrites those parameters: no G-issue body cites `ridershipByLine`, so renaming now desyncs nothing, and it avoids a second pass over the same file.

## The issue's site table is stale

#153 lists five occurrences in `src/hooks/useUserDashboardInput.ts`. Those no longer exist — #167 deleted `updateLinesWithLineMetrics` and they went with it. Completeness here is judged against a fresh grep of the branch, not the issue's table.

## Acceptance grep

```
$ grep -rn "ridershipByLine" src/ e2e/
src/plans/collapse-calc-into-line-metrics.md:437:  `buildWindowMonthAxis(ridershipByLine)`, the union over *every* line (`chartData.ts:115`), so it
src/plans/collapse-calc-into-line-metrics.md:515:exactly two derivation calls — `buildCoverageByLine(ridershipByLine)` once, and `lineMetrics({...})`
src/plans/context-logs.md:46:Add a `transitEvents` useMemo (alongside the existing `chartDatasets` + `ridershipByLine` memo) that:
src/plans/derived-figures-off-line-state.md:250:                   ridershipByLine[line.id];
src/plans/ridership-view-module.md:319:`JSON.stringify(ridershipByLine)`) from thrashing. Do **not** convert the dependency array to
src/plans/ridership-view-module.md:326:Rename at the call sites: `chartDatasets` → `datasets`, `monthList` → `months`, `ridershipByLine` →
src/plans/ridership-view-module.md:331:<LineSelector ... ridershipByLine={consolidated} />
```

Nothing outside `src/plans/`. ✅

## Gate

```
npm run lint    → clean
npm test        → 20 files, 585 tests passed
npm run build   → tsc -b + vite build, built in 14.40s
npm run test:e2e → 44 passed, 7 skipped (51 total, 3.8m)
```

**No baseline moved.** The first local e2e run reported "A snapshot doesn't exist … writing actual" for the `-win32.png` files — this worktree was fresh and had no local scratch baselines. Those files are gitignored per-developer scratch (`.gitignore:26: e2e/**/*-snapshots/*-win32.png`); `git status` stayed clean of PNGs throughout. The re-run against the written scratch passed. No committed `-linux` baseline is modified, and **`npm run test:e2e:update` / `:update:linux` were not run** — regenerating baselines is not this PR's call. CI's Linux e2e job is the authoritative gate.

## Merge

**I do not merge.** Merge authority in this repo stays with Michael.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
