### PR TITLE
fix(pipeline): stop zero padding from overwriting committed ridership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,10 @@ Each one has cost someone real time. The reasoning is in `docs/`; this is the sh
   committed chart baselines — [ADR-0001](docs/adr/0001-ridership-month-window-is-deliberately-offset.md).
   The Event Window disagreeing with it is also intended.
 - **Don't set `spanGaps`** on the chart. A month a line doesn't report is a gap, not a zero.
+- **Don't make `fill_missing_months` pad anything but a line's leading gap**, and don't let its pads
+  become `0` before `merge_ridership` has backfilled them. A pad is NaN so the merge can tell it from
+  a line that genuinely reported zero riders — line 60 did, in 2026-01 — so a backfill keyed on `== 0`
+  is wrong. Pad the start, not the end: see *Settled* in [docs/ROADMAP.md](docs/ROADMAP.md).
 - **Don't add a derived field to `Line`.** Figures belong on a Line Readout and last only as long as
   the window that produced them — [ADR-0005](docs/adr/0005-derived-figures-live-on-line-readouts.md).
   The write-back that used to do this was deleted in #167; don't reintroduce it.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@ PRs update it rather than restating their own scope.
 
 | PR | Contents | Gate | Status |
 | --- | --- | --- | --- |
-| **1** | `stop_identity.py`, `stop_aliases.json`, the `extract_leaf_rows` refactor, `aggregate_to_stop_ridership`, tests. **No data change.** | `pytest scripts/` green with the six existing test files unmodified; a full re-ingest produces byte-for-byte what it produced at the base commit (see below) | ☐ |
+| **1** | `stop_identity.py`, `stop_aliases.json`, the `extract_leaf_rows` refactor, `aggregate_to_stop_ridership`, tests. **No data change.** | `pytest scripts/` green with the six existing test files unmodified; a full re-ingest produces byte-for-byte what it produced at the base commit (see below) | ☑ [#173](https://github.com/streetsforall/metro_ridership_app/pull/173) |
 | **2** | `fetch_stop_locations.py`, `src/data/stop_locations.json`, `scripts/README.md`, tests | Match rate reported; unmatched reviewed and aliases extended | ☐ |
 | **3** | `stop_ridership.py`, `update_ridership.py` wiring, the two data files, `DATA_RELEASE_NOTES.md` | Reconciliation within tolerance; two runs byte-identical | ☐ |
 | **4** | Vite plugin, manifest, `src/stops/`, `stops.types.ts`, the `isInMonthWindow` extraction, vitest specs. **No visible UI.** | `ANALYZE=1 npm run build` — entry chunk unchanged; no visual baseline moves | ☐ |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,8 +9,9 @@ stop/station-level with ons, offs and activity for all three day types;
 `aggregate_to_line_ridership` used to `groupby("LINE").sum()` and discard stop
 identity, offs and activity at ingest. Nothing needs to be acquired.
 
-Coverage is **2025-07 → 2026-05, 11 months, both modes**. Everything before that is
-line-level only and stays untouched.
+Coverage is **2025-07 → 2026-06, 12 months, both modes** — 11 at the time this was
+written, plus 2026-06 from #176. Everything before that is line-level only and stays
+untouched.
 
 ## The five PRs
 
@@ -42,41 +43,69 @@ Judge the gate against a **control run at the base commit**, not against the com
 file: the re-ingest must produce byte-for-byte what it produced before the change. PR 1
 does (`sha256 f03df3a9…` for both runs).
 
-#### Settled: the committed file is right, the five rows are wrong
+The five synthesised rows are gone as of the padding fix below — but the gate does not
+change, because a re-ingest still moves one value (line 602 at 2025-11, Saturday 238 →
+237, a re-derivation of the days-weighted mean). **The control run remains the baseline.**
+
+#### Settled: the committed file is right, the synthesised rows are wrong
 
 Neither answer in the original framing was correct — `ridership.json` is not stale, and
 line 106 is not missing data. **Line 106 was discontinued.** It ran normally to the end
 of 2025 (158 stops, 4,062 weekday boardings in 2025-12), is absent from every export
-from 2026-01 on — the *only* line dropped anywhere in the 11-month window — and is gone
+from 2026-01 on — the *only* line dropped anywhere in the window — and is gone
 from `public/metro_lines.geojson`, so Metro's own GTFS no longer carries it either.
 
-A zero row asserts the line ran and carried nobody. Writing five of them would draw
-line 106 plunging from 4,062 to a five-month flatline along the axis, which reads as a
-ridership collapse rather than a line that ended. `CLAUDE.md` already has the words for
-this: *a month a line doesn't report is a gap, not a zero.*
+A zero row asserts the line ran and carried nobody. Writing them would draw line 106
+plunging from 4,062 to a flatline along the axis, which reads as a ridership collapse
+rather than a line that ended — and the flatline grows by one month with every export
+that lands. `CLAUDE.md` already has the words for this: *a month a line doesn't report
+is a gap, not a zero.*
 
 The rows appear because `fill_missing_months` cross-joins **the batch's** month range
 with **the batch's** line set. Incremental ingests each covered a narrow range, so a line
 that starts or stops mid-window was never padded across months outside its own batch. One
-full re-ingest spans all 11 months at once and pads everything. Line 74 is the mirror
+full re-ingest spans every month at once and pads everything. Line 74 is the mirror
 image and is already in the committed file — five zeros for 2025-07 … 11, then real data
 from 2025-12 — because its batch's range covered those months. So the file's working
 convention is **pad the start, not the end**: at 2026-05 there are 114 lines and not one
 with zero weekday ridership.
 
 **Action for PR 3: none, beyond not "fixing" it.** Do not chase a clean
-`git diff src/data/ridership.json` after a full re-ingest, and do not add the five rows.
+`git diff src/data/ridership.json` after a full re-ingest, and do not add the rows.
 
-**Separately — a live footgun PR 3 must not walk into.** `merge_ridership`'s docstring
-promises that "gaps in new data (within its date range) are backfilled from existing data
-before the concat, preserving non-zero historical values." That backfill is
-**unreachable**: its mask is `isnull(new) & notnull(old)`, but `fill_missing_months` has
-already `.fillna(0)`'d every gap, so the new side is never null (0 nulls survive it).
-Meanwhile `pd.concat([merged, current]).drop_duplicates(keep="first")` lets the new rows
-win. So a wide-range re-ingest **can overwrite real committed ridership with zeros**, and
-the guard that is supposed to prevent exactly that does not run. Today it only surfaces as
-five insertions because line 106's rows are absent rather than present-and-nonzero.
-Nobody has fixed this; it is in `process_ridership.py`, which is out of scope for PR 1.
+#### The padding rule is now enforced in code
+
+Everything above described a convention the *data* followed and the *code* did not. Until
+this was fixed, "pad the start, not the end" held only because the archives happen to be
+delivered in narrow batches — feed the same months in as one wide batch and the padding
+reappeared. `fill_missing_months` now pads a line's **leading** gap only. Months after a
+line's last report, and interior months it skipped, are left absent.
+
+**And the footgun that came with it is closed.** `merge_ridership`'s docstring promised
+that "gaps in new data (within its date range) are backfilled from existing data before
+the concat, preserving non-zero historical values." That backfill was **unreachable**: its
+mask is `isnull(new) & notnull(old)`, but `fill_missing_months` had already `.fillna(0)`'d
+every gap, so the new side was never null. Meanwhile
+`pd.concat([merged, current]).drop_duplicates(keep="first")` let the new rows win — so a
+wide-range re-ingest **could overwrite real committed ridership with zeros**, for any line
+whose reporting is discontinuous inside the range, with the guard meant to prevent exactly
+that sitting dead. It never fired on this data only because line 106's rows are absent
+rather than present-and-nonzero.
+
+Pads are now left as **NaN**, not `0`, which is what makes the existing mask reachable and
+its docstring true. The NaN is load-bearing, and this is the part to not undo:
+
+> **Padding cannot be detected by value — a real row may be all zeros.** Line 60 genuinely
+> reported `0/0/0` for 2026-01. A backfill keyed on `== 0` instead of `isnull` would read
+> that as padding and resurrect stale figures over a real zero report. Reported-ness comes
+> from the merge indicator, never from the numbers.
+
+Measured on a single wide batch over all five archives (2025-07 … 2026-06, 115 lines):
+before, `42,747 → 42,753` records, writing six zero rows for line 106; after, `42,747 →
+42,747` and none. Per-archive re-ingest is byte-identical to its control run.
+
+`update_ridership.py`'s `diff_against_current` moved in step — a pad is not a pending
+correction, and without that `--overwrite` reported 8 corrections where 1 was real.
 
 ## The contract PR 1 freezes
 

--- a/scripts/process_ridership.py
+++ b/scripts/process_ridership.py
@@ -100,15 +100,38 @@ def compute_ridership(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def fill_missing_months(df: pd.DataFrame) -> pd.DataFrame:
-    """Cross-join all year/month combos with all lines so every line has a row
-    for every month in the new dataset's range.  Gaps are filled with 0."""
+    """Pad each line's *leading* gap: every line gets a row for each month from
+    the start of this batch's range up to its own first reported month.
+
+    Pad the start, not the end.  This matches the convention the committed file
+    already follows — line 74 carries five pad months for 2025-07…11 before its
+    first real 2025-12 report.  Months *after* a line's last report in the
+    batch, and interior months it skipped, are deliberately left absent: a zero
+    row asserts the line ran and carried nobody, which is a stronger and
+    usually false claim than "did not report".  So a line discontinued
+    mid-batch ends where its data ends, and one that paused and resumed keeps a
+    genuine gap.
+
+    Pad rows are left as NaN rather than 0.  That is what lets merge_ridership
+    tell a manufactured pad from a line that genuinely reported zero riders
+    (line 60 did, in 2026-01); it backfills the pads against committed history
+    and zeroes whatever survives.
+    """
+    keys = ["year", "month", "line_name"]
     unique_ym = df[["year", "month"]].drop_duplicates()
     unique_lines = df[["line_name"]].drop_duplicates()
     calendar = unique_ym.merge(unique_lines, how="cross")
+    padded = calendar.merge(df, on=keys, how="left", indicator=True)
+
+    # Reported-ness comes from the merge, not from the values: a real row may
+    # legitimately be all zeros, and a line missing a DayType pivots to NaN.
+    reported = padded["_merge"] == "both"
+    period = padded["year"] * 12 + padded["month"]
+    first_report = period.where(reported).groupby(padded["line_name"]).transform("min")
+
     return (
-        calendar.merge(df, on=["year", "month", "line_name"], how="left")
-        .fillna(0)
-        .sort_values(["year", "month", "line_name"])
+        padded[reported | (period < first_report)]
+        .sort_values(keys)
         .reset_index(drop=True)
     )[RIDERSHIP_COLS]
 
@@ -118,39 +141,50 @@ def merge_ridership(
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Merge new records with existing ridership.json.
 
+    ``new_df`` is expected to come from fill_missing_months, so its pad rows are
+    NaN and its real rows — including any that genuinely report zero riders —
+    are not.
+
     With ``prefer_new=True`` (default):
     - New data wins when both new and existing have a record for the same key.
-    - Gaps in new data (within its date range) are backfilled from existing data
-      before the concat, preserving non-zero historical values.
+    - Pad rows are backfilled from existing data before the concat, so padding
+      never overwrites a real historical value.  A pad with no history behind it
+      becomes 0.
     - Existing records outside the new dataset's date range are always preserved.
 
     With ``prefer_new=False`` (append-only):
     - Existing records always win; only keys absent from ridership.json are added.
-      No backfill is needed since existing rows are kept verbatim.
+      No backfill is needed since existing rows are kept verbatim; pads that land
+      on a new key become 0.
     """
     with open(RIDERSHIP_PATH) as f:
         current = pd.DataFrame(json.load(f))
 
     keys = ["year", "month", "line_name"]
+    value_cols = ["est_wkday_ridership", "est_sat_ridership", "est_sun_ridership"]
 
     if not prefer_new:
+        appended = new_df[RIDERSHIP_COLS].copy()
+        appended[value_cols] = appended[value_cols].fillna(0)
         final = (
-            pd.concat([current, new_df[RIDERSHIP_COLS]])
+            pd.concat([current, appended])
             .drop_duplicates(subset=keys, keep="first")
             .sort_values(keys)
             .reset_index(drop=True)
         )
         return final, current
 
-    # Backfill zeros in new_df from current where current has real values
+    # Backfill pads in new_df from current where current has a record at all.
     merged = new_df.merge(
         current, on=keys, how="left", suffixes=("_new", "_old")
     )
-    for col in ["est_wkday_ridership", "est_sat_ridership", "est_sun_ridership"]:
+    for col in value_cols:
         mask = merged[f"{col}_new"].isnull() & merged[f"{col}_old"].notnull()
         merged.loc[mask, f"{col}_new"] = merged.loc[mask, f"{col}_old"]
     merged.columns = merged.columns.str.replace("_new", "", regex=False)
-    merged = merged[RIDERSHIP_COLS]
+    merged = merged[RIDERSHIP_COLS].copy()
+    # Pads with nothing behind them: the line had not started reporting yet.
+    merged[value_cols] = merged[value_cols].fillna(0)
 
     final = (
         pd.concat([merged, current])

--- a/scripts/test_process_ridership.py
+++ b/scripts/test_process_ridership.py
@@ -205,17 +205,76 @@ class TestFillMissingMonths:
         result = fill_missing_months(df)
         assert len(result) == 1
 
-    def test_missing_line_filled_with_zeros(self):
-        """Line 2 has data for Jan; line 4 does not.  Line 4 should get a zero row."""
+    def test_leading_gap_padded(self):
+        """Line 4 starts reporting in Feb; it gets a pad row for Jan."""
+        df = pd.DataFrame([
+            self._base(line_name=2, month=1),
+            self._base(line_name=2, month=2),
+            self._base(line_name=4, month=2),
+        ])
+        result = fill_missing_months(df)
+
+        pad = result[(result["line_name"] == 4) & (result["month"] == 1)]
+        assert len(pad) == 1
+        assert pd.isna(pad.iloc[0]["est_wkday_ridership"])
+
+    def test_pad_rows_are_null_not_zero(self):
+        """Pads must stay NaN so merge_ridership can tell them from a line that
+        genuinely reported zero riders."""
         df = pd.DataFrame([
             self._base(line_name=2, month=1),
             self._base(line_name=4, month=2),
         ])
         result = fill_missing_months(df)
-        # 2 lines × 2 months = 4 rows
+
+        pad = result[(result["line_name"] == 4) & (result["month"] == 1)]
+        assert pad[pr.RIDERSHIP_COLS[3:]].isnull().all().all()
+
+    def test_trailing_gap_not_padded(self):
+        """The line-106 shape: a line that stops reporting mid-batch gets no
+        rows for the months after its last report.  A zero row there would
+        assert the line ran and carried nobody."""
+        df = pd.DataFrame([
+            self._base(line_name=2, month=m) for m in (1, 2, 3)
+        ] + [
+            self._base(line_name=106, month=1),
+        ])
+        result = fill_missing_months(df)
+
+        trailing = result[(result["line_name"] == 106) & (result["month"] > 1)]
+        assert trailing.empty
         assert len(result) == 4
-        missing = result[(result["line_name"] == 2) & (result["month"] == 2)]
-        assert missing.iloc[0]["est_wkday_ridership"] == 0
+
+    def test_interior_gap_not_padded(self):
+        """A line that reported, paused, and resumed keeps a real gap."""
+        df = pd.DataFrame([
+            self._base(line_name=2, month=m) for m in (1, 2, 3)
+        ] + [
+            self._base(line_name=4, month=1),
+            self._base(line_name=4, month=3),
+        ])
+        result = fill_missing_months(df)
+
+        gap = result[(result["line_name"] == 4) & (result["month"] == 2)]
+        assert gap.empty
+
+    def test_all_zero_report_is_not_treated_as_missing(self):
+        """Line 60 genuinely reported zeros in 2026-01.  Reported-ness comes
+        from the merge, not the values, so such a row is kept as reported — and
+        therefore still anchors where padding stops."""
+        df = pd.DataFrame([
+            self._base(line_name=2, month=1),
+            self._base(line_name=2, month=2),
+            self._base(line_name=60, month=1, est_wkday_ridership=0.0,
+                       est_sat_ridership=0.0, est_sun_ridership=0.0),
+        ])
+        result = fill_missing_months(df)
+
+        jan = result[(result["line_name"] == 60) & (result["month"] == 1)]
+        assert len(jan) == 1
+        assert jan.iloc[0]["est_wkday_ridership"] == 0
+        # Feb is trailing for line 60, so it is absent rather than padded.
+        assert result[(result["line_name"] == 60) & (result["month"] == 2)].empty
 
     def test_existing_values_preserved(self):
         df = pd.DataFrame([
@@ -304,6 +363,69 @@ class TestMergeRidership:
 
         assert final.equals(current)
 
+    def test_pad_does_not_overwrite_existing_value(self, tmp_path, monkeypatch):
+        """The regression this whole backfill exists for: a pad row (NaN) must
+        never replace a real committed figure with a zero."""
+        make_ridership_json([self._rec(month=1, est_wkday_ridership=4062.0)],
+                            tmp_path / "r.json")
+        monkeypatch.setattr(pr, "RIDERSHIP_PATH", tmp_path / "r.json")
+
+        new_df = pd.DataFrame([self._rec(
+            month=1, est_wkday_ridership=float("nan"),
+            est_sat_ridership=float("nan"), est_sun_ridership=float("nan"),
+        )])
+        final, _ = merge_ridership(new_df)
+
+        assert final.iloc[0]["est_wkday_ridership"] == 4062.0
+        assert final.iloc[0]["est_sat_ridership"] == 500.0
+
+    def test_genuine_zero_report_still_wins(self, tmp_path, monkeypatch):
+        """A line that really reported zero riders is not a pad: it overwrites
+        the existing value like any other new figure.  This is what a mask
+        keyed on ``== 0`` instead of ``isnull`` would get wrong."""
+        make_ridership_json([self._rec(month=1, est_wkday_ridership=4062.0)],
+                            tmp_path / "r.json")
+        monkeypatch.setattr(pr, "RIDERSHIP_PATH", tmp_path / "r.json")
+
+        new_df = pd.DataFrame([self._rec(
+            month=1, est_wkday_ridership=0.0,
+            est_sat_ridership=0.0, est_sun_ridership=0.0,
+        )])
+        final, _ = merge_ridership(new_df)
+
+        assert final.iloc[0]["est_wkday_ridership"] == 0.0
+
+    def test_unbacked_pad_written_as_zero(self, tmp_path, monkeypatch):
+        """A pad for a key ridership.json has never seen is zero-filled, not
+        left as a JSON null."""
+        make_ridership_json([self._rec(month=1)], tmp_path / "r.json")
+        monkeypatch.setattr(pr, "RIDERSHIP_PATH", tmp_path / "r.json")
+
+        new_df = pd.DataFrame([self._rec(
+            month=2, est_wkday_ridership=float("nan"),
+            est_sat_ridership=float("nan"), est_sun_ridership=float("nan"),
+        )])
+        final, _ = merge_ridership(new_df)
+
+        feb = final[final["month"] == 2].iloc[0]
+        assert feb["est_wkday_ridership"] == 0.0
+        assert not final.isnull().any().any()
+
+    def test_append_only_zero_fills_pads(self, tmp_path, monkeypatch):
+        """prefer_new=False appends pads too; they must not reach the JSON as
+        nulls."""
+        make_ridership_json([self._rec(month=1)], tmp_path / "r.json")
+        monkeypatch.setattr(pr, "RIDERSHIP_PATH", tmp_path / "r.json")
+
+        new_df = pd.DataFrame([self._rec(
+            month=2, est_wkday_ridership=float("nan"),
+            est_sat_ridership=float("nan"), est_sun_ridership=float("nan"),
+        )])
+        final, _ = merge_ridership(new_df, prefer_new=False)
+
+        assert final[final["month"] == 2].iloc[0]["est_wkday_ridership"] == 0.0
+        assert not final.isnull().any().any()
+
     def test_append_only_preserves_existing_on_conflict(self, tmp_path, monkeypatch):
         """prefer_new=False: an existing key keeps its old value; only absent
         keys are added."""
@@ -321,6 +443,95 @@ class TestMergeRidership:
         assert jan["est_wkday_ridership"] == 999.0  # existing preserved
         assert feb["est_wkday_ridership"] == 555.0  # new appended
         assert len(final) == 2 and len(current) == 1
+
+
+# ---------------------------------------------------------------------------
+# compute_ridership -> fill_missing_months -> merge_ridership
+#
+# The padding hazard only shows up end-to-end: fill_missing_months manufactures
+# rows for months a line never reported, and merge_ridership lets new data win.
+# ---------------------------------------------------------------------------
+
+class TestIngestPipeline:
+    def _raw(self, month, line, riders):
+        """One month of one line, all three DayTypes at the same figure."""
+        return [
+            dict(year=2026, month=month, line=line, daytype=dt, riders=riders,
+                 shakeup=202512, provider="DO", mode="Bus", days=20)
+            for dt in ("DX", "SA", "SU")
+        ]
+
+    def _ingest(self, raw_rows, tmp_path, monkeypatch, existing):
+        make_ridership_json(existing, tmp_path / "r.json")
+        monkeypatch.setattr(pr, "RIDERSHIP_PATH", tmp_path / "r.json")
+        new_df = fill_missing_months(compute_ridership(make_raw(raw_rows)))
+        final, _ = merge_ridership(new_df)
+        return final
+
+    def _rec(self, month, line, riders):
+        return dict(year=2026, month=month, line_name=line,
+                    est_wkday_ridership=float(riders),
+                    est_sat_ridership=float(riders),
+                    est_sun_ridership=float(riders))
+
+    # merge_ridership reads ridership.json as a DataFrame, so it needs at least
+    # one row to have columns to merge on.  This one is outside every batch's
+    # range and so never participates.
+    _UNRELATED = dict(year=2020, month=1, line_name=999,
+                      est_wkday_ridership=1.0, est_sat_ridership=1.0,
+                      est_sun_ridership=1.0)
+
+    def test_pause_and_resume_does_not_zero_committed_history(
+        self, tmp_path, monkeypatch
+    ):
+        """Line 4 reported in Jan and Mar but not Feb.  A batch spanning Jan–Mar
+        pads Feb; that pad must not overwrite the real Feb figure already in
+        ridership.json."""
+        raw = (
+            self._raw(1, 2, 1000) + self._raw(2, 2, 1100) + self._raw(3, 2, 1200)
+            + self._raw(1, 4, 500) + self._raw(3, 4, 600)
+        )
+        final = self._ingest(raw, tmp_path, monkeypatch, existing=[
+            self._rec(1, 4, 500), self._rec(2, 4, 550), self._rec(3, 4, 600),
+        ])
+
+        feb = final[(final["line_name"] == 4) & (final["month"] == 2)]
+        assert len(feb) == 1
+        assert feb.iloc[0]["est_wkday_ridership"] == 550.0
+
+    def test_discontinued_line_gets_no_trailing_zero_rows(
+        self, tmp_path, monkeypatch
+    ):
+        """The line-106 case: line 106 stops reporting after Jan.  A Jan–Mar
+        batch must not write Feb/Mar rows claiming it carried nobody."""
+        raw = (
+            self._raw(1, 2, 1000) + self._raw(2, 2, 1100) + self._raw(3, 2, 1200)
+            + self._raw(1, 106, 4062)
+        )
+        final = self._ingest(raw, tmp_path, monkeypatch, existing=[
+            self._rec(1, 106, 4062),
+        ])
+
+        assert final[(final["line_name"] == 106) & (final["month"] > 1)].empty
+        assert len(final) == 4
+
+    def test_line_start_is_padded_with_zeros(self, tmp_path, monkeypatch):
+        """The line-74 case, and the reason padding exists at all: a line whose
+        first report falls mid-batch gets zeros for the months before it."""
+        raw = (
+            self._raw(1, 2, 1000) + self._raw(2, 2, 1100) + self._raw(3, 2, 1200)
+            + self._raw(3, 74, 2979)
+        )
+        final = self._ingest(raw, tmp_path, monkeypatch, existing=[self._UNRELATED])
+
+        line74 = final[final["line_name"] == 74].sort_values("month")
+        assert list(line74["month"]) == [1, 2, 3]
+        assert list(line74["est_wkday_ridership"]) == [0.0, 0.0, 2979.0]
+
+    def test_no_nulls_reach_the_output(self, tmp_path, monkeypatch):
+        raw = self._raw(1, 2, 1000) + self._raw(2, 2, 1100) + self._raw(2, 74, 900)
+        final = self._ingest(raw, tmp_path, monkeypatch, existing=[self._UNRELATED])
+        assert not final.isnull().any().any()
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/test_update_ridership.py
+++ b/scripts/test_update_ridership.py
@@ -106,6 +106,24 @@ class TestLoadAndComputeFillScoping:
         assert len(new_df[(new_df["line_name"] == 90) & (new_df["month"] == 1)]) == 1
 
 
+class TestDiffAgainstCurrent:
+    def test_pads_are_not_counted_as_corrections(self, tmp_path, monkeypatch):
+        """fill_missing_months leaves pads as NaN and merge_ridership backfills
+        them, so a pad over an existing record is not a pending correction."""
+        _setup_data(tmp_path, monkeypatch, [_rec(month=1, wk=100.0)])
+
+        new_df = pd.DataFrame([_rec(
+            month=1, wk=float("nan"), sa=float("nan"), su=float("nan"),
+        )])
+        assert ur.diff_against_current(new_df, overwrite=True)["updated_records"] == 0
+
+    def test_real_change_still_counted(self, tmp_path, monkeypatch):
+        _setup_data(tmp_path, monkeypatch, [_rec(month=1, wk=100.0)])
+
+        new_df = pd.DataFrame([_rec(month=1, wk=123.0)])
+        assert ur.diff_against_current(new_df, overwrite=True)["updated_records"] == 1
+
+
 # ---------------------------------------------------------------------------
 # main — append-only / overwrite / no-op
 # ---------------------------------------------------------------------------

--- a/scripts/update_ridership.py
+++ b/scripts/update_ridership.py
@@ -68,8 +68,10 @@ def load_and_compute(
     """Load each input file and compute its wide per-line ridership.
 
     fill_missing_months is applied *per file* (i.e. per delivered batch) so a
-    line that ran in one archive's months is only zero-filled within that
-    archive's range — never cross-joined into unrelated months from other files.
+    line that ran in one archive's months is only padded within that archive's
+    range — never cross-joined into unrelated months from other files.  Its pads
+    come back as NaN; merge_ridership resolves them against committed history
+    and zeroes the rest.
 
     Returns:
       new_df   -- combined wide ridership (KEYS deduped; loose-xlsx vs. zip
@@ -111,7 +113,10 @@ def diff_against_current(new_df: pd.DataFrame, overwrite: bool) -> dict:
     both = merged[merged["_merge"] == "both"]
     changed = pd.Series(False, index=both.index)
     for col in VALUE_COLS:
-        changed |= both[f"{col}_new"].astype(float) != both[f"{col}_old"].astype(float)
+        new_vals = both[f"{col}_new"].astype(float)
+        # A NaN is a fill_missing_months pad, not a figure.  merge_ridership
+        # backfills it from the existing record, so it is never a correction.
+        changed |= new_vals.notna() & (new_vals != both[f"{col}_old"].astype(float))
     updated_count = int(changed.sum()) if overwrite else 0
 
     return {


### PR DESCRIPTION
`merge_ridership`'s docstring promises that gaps in new data are backfilled from existing data, "preserving non-zero historical values". **That backfill never ran.** Its mask is `isnull(new) & notnull(old)`, but `fill_missing_months` had already `.fillna(0)`'d every gap, so the new side was never null — 0 nulls survive it. The concat then let the zero-filled rows win over committed history.

Consequence: a wide-range re-ingest could overwrite real ridership with zeros for any line whose reporting is discontinuous inside the range — a line that ran, paused, and resumed. Latent on today's data only because the one affected line (106) is *absent* from `ridership.json` rather than present-and-nonzero, so it manifested as insertions rather than corruption.

## What changed

**`fill_missing_months` pads a line's leading gap only, and leaves pads as `NaN`.** Months after a line's last report, and interior months it skipped, are left absent. A zero row asserts the line ran and carried nobody, which is a stronger and usually false claim than "did not report". This is the file's existing convention — *pad the start, not the end* — now enforced by the code rather than by how narrowly the archives happen to be split.

**The NaN is load-bearing, and is the part not to undo.** Padding cannot be detected by value: line 60 genuinely reported `0/0/0` for 2026-01. A backfill keyed on `== 0` instead of `isnull` would read that as padding and resurrect stale figures over a real zero report. Reported-ness now comes from the merge indicator, never from the numbers.

**`merge_ridership`'s existing mask is reachable** and does what it always claimed. Pads with no history behind them are zeroed after the backfill, on both the `prefer_new` and append-only paths, so nothing reaches the JSON as `null`.

**`update_ridership.diff_against_current` moves in step** — a pad is not a pending correction. Without this, `--overwrite` reported 8 corrections where 1 was real. This file was outside the original scope; it is here because the shared-helper change caused the regression.

## Verification

The committed `ridership.json` is not the fixed point of its own pipeline, so everything below is judged against a **control run at the base commit**, not a clean `git diff` — see *About PR 1's gate* in `docs/ROADMAP.md`.

| Check | Result |
| --- | --- |
| `pytest scripts/` | 299 passed |
| Per-archive re-ingest, all 5 archives | **byte-identical** to the control run (`sha256 4e2999af…`) |
| Control vs committed | one value, unrelated to this change: line 602 at 2025-11, Sat 238 → 237 |
| One wide batch, 2025-07 … 2026-06, 115 lines | before `42,747 → 42,753`, writing six zero rows for line 106; after `42,747 → 42,747`, none |
| Committed non-zero values zeroed | 0, before and after |

`src/data/` restored after every run.

## Tests

`TestFillMissingMonths` — leading pad kept, pads are NaN, trailing gap dropped (the line-106 shape), interior gap dropped, all-zero report is not treated as missing.

`TestMergeRidership` — pad does not overwrite an existing value, a genuine zero report still wins, unbacked pad → 0, append-only pad → 0.

`TestIngestPipeline` (new) — `compute_ridership` → `fill_missing_months` → `merge_ridership` end to end, for the pause-and-resume, line-106 and line-74 shapes. This is where "can overwrite real data with zeros" is actually pinned; the hazard only exists end to end, which is why it survived the unit tests that already covered each function.

`TestDiffAgainstCurrent` (new) — pads aren't counted as corrections; real changes still are.

## Docs

`docs/ROADMAP.md`'s *Settled* section already carried the line-106 reasoning and flagged this backfill as a live footgun for PR 3. The reasoning stays; the footgun paragraph is replaced with what was done. Row counts are de-pinned — "the five rows" became six when #176 landed 2026-06 and would grow with the next export — and coverage is updated to 12 months for the same reason.

`CLAUDE.md` gains one invariant, next to the `spanGaps` one it is the pipeline-side twin of.

No UI change, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
