### PR TITLE
refactor(ridership): state each window rule once, in month.ts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,9 @@ npm run docs:architecture      # regenerate the diagram set
 ```
 
 One test file: `npx vitest run src/ridership/lineMetrics.test.ts`, or filter by name with `-t`.
-Vitest runs with globals enabled — no per-file imports of `describe`/`it`/`expect`.
+**Every spec imports `describe`/`it`/`expect` from `vitest`.** `vitest.config.ts` sets
+`globals: true` so the runtime doesn't need them, but `tsconfig.app.json` doesn't list
+`vitest/globals`, so `tsc -b` doesn't see them and `npm run build` fails without the import.
 
 Python pipeline: `pip install -r scripts/requirements.txt`, then `pytest scripts/`.
 
@@ -60,6 +62,12 @@ Each one has cost someone real time. The reasoning is in `docs/`; this is the sh
 - **Don't silently change the Month Window's off-by-one.** It is intended and pinned by the
   committed chart baselines — [ADR-0001](docs/adr/0001-ridership-month-window-is-deliberately-offset.md).
   The Event Window disagreeing with it is also intended.
+- **Don't restate either window rule at a call site.** Each is stated once, in
+  [`src/utils/month.ts`](src/utils/month.ts) — `containsOffset` and `contains` — and reached through
+  the `Date`-shaped adapters `isInMonthWindow` and `isInEventWindow` in `src/ridership/`. A second
+  copy is how the panels start disagreeing about which months a URL shows.
+- **Don't hand a window bound a day or a time.** Every producer builds `new Date(y, m - 1)`, midnight
+  on the first, and both adapters read only the year and month off it.
 - **Don't set `spanGaps`** on the chart. A month a line doesn't report is a gap, not a zero.
 - **Don't make `fill_missing_months` pad anything but a line's leading gap**, and don't let its pads
   become `0` before `merge_ridership` has backfilled them. A pad is NaN so the merge can tell it from

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -208,9 +208,16 @@ reconciliation caveat.
 
 ## Named risks
 
-1. **Forking the Month Window** — highest. PR 4 extracts `isInMonthWindow` and both
-   derivations call it. [ADR-0001](adr/0001-ridership-month-window-is-deliberately-offset.md)
-   exists because this arithmetic drifted once already.
+1. **Forking the Month Window** — was highest, now **closed**.
+   [ADR-0001](adr/0001-ridership-month-window-is-deliberately-offset.md) exists because
+   this arithmetic drifted once already. PR 4 extracted `isInMonthWindow` so both
+   derivations called one copy; the follow-up closed the rest. Each rule is stated once
+   in `src/utils/month.ts` — `containsOffset` for the Month Window, `contains` for the
+   Event Window — with `src/ridership/monthWindow.ts` and `src/ridership/eventWindow.ts`
+   as the `Date`-shaped adapters production calls. The Event Window had the same fork
+   shape and is fixed the same way. Bounds must stay month-aligned; see ADR-0001's
+   addendum. **The rule that replaces this one: don't restate either window at a call
+   site.**
 2. **3.8 MB reaching first paint** — the bus file loads only when the stop panel is
    on *and* a bus-export line is selected, inside `OutputArea`'s lazy chunk. This is
    the failure that would undo that lazy-load.

--- a/docs/adr/0001-ridership-month-window-is-deliberately-offset.md
+++ b/docs/adr/0001-ridership-month-window-is-deliberately-offset.md
@@ -30,3 +30,36 @@ drive-by fix.
 - The Event Window, which filters context-log events from the same user choices, is **inclusive on
   both ends**. The two windows genuinely disagree. That is preserved as-is: reconciling them would
   change which events appear for a given URL.
+
+## Addendum — the arithmetic was replaced; the boundaries were not
+
+The consequence above about keeping the `Date` arithmetic **verbatim** no longer describes the code,
+and the reason it stopped holding is worth recording. That argument — copy-paste is provably
+non-drifting, algebra is only provably equivalent if the algebra is right — was sound while there was
+one statement of the rule. It stopped being sound once `src/utils/month.ts` grew `containsOffset`, a
+second statement over `Month` ordinals, because from then on **two** statements existed and the fork
+this ADR exists to prevent was already open, whichever one production happened to call.
+
+So each rule is now stated exactly once, in `src/utils/month.ts`, and production reaches it through a
+`Date`-shaped adapter in `src/ridership/`:
+
+| rule | statement | adapter | callers |
+| --- | --- | --- | --- |
+| Month Window, `S ≤ R ≤ E − 2` | `month.ts` `containsOffset` | `ridership/monthWindow.ts` `isInMonthWindow` | the chart's Ridership View, the stop panel's Stop View |
+| Event Window, `S ≤ R ≤ E` | `month.ts` `contains` | `ridership/eventWindow.ts` `isInEventWindow` | the context log |
+
+The boundaries did not move, and this ADR's licence is what permitted the swap: *"a `Month` module
+that unifies the app's several month encodings may replace the arithmetic; it may not change these
+boundaries."* What makes it safe is the third bullet above, not the derivation —
+`monthWindow.test.ts` runs the live function, `containsOffset`, and the retired `Date` comparison
+against each other over every window pair in a decade. **The retired comparison is kept in that spec
+verbatim for exactly this purpose**: with `isInMonthWindow` now delegating, checking it against
+`containsOffset` alone would be a tautology, and the old arithmetic is the only comparand in the file
+that cannot move.
+
+One new obligation falls out of the swap. The ordinal form compares months where the `Date` form
+compared timestamps, so **window bounds must stay month-aligned** — `new Date(y, m − 1)`, midnight on
+the first. Every producer is (`parseMonthParam`, `DefaultStartDate`, `dataDefaultEndDate`,
+`labelToDate`, and `DateRangeSelector`, which mutates an already-aligned date). A bound carrying a day
+or a time would be truncated to its month rather than compared. ADR-0006 is the standing argument for
+why these bounds should not be `Date`s at all.

--- a/docs/architecture/captions.md
+++ b/docs/architecture/captions.md
@@ -173,6 +173,12 @@ This reads like an off-by-one and is not. It is long-standing behaviour, users h
 against it, and `e2e/chart-content.spec.ts` renders windows through it into committed PNG
 baselines, so normalising it would change what every existing link shows. ADR-0001 accepts it.
 
+Each rule is stated exactly once, in `utils/month.ts` — `containsOffset` and `contains` — and
+production reaches it through a `Date`-shaped adapter (`ridership/monthWindow.ts`,
+`ridership/eventWindow.ts`). Two copies of a rule this surprising is how the chart and the stop
+panel would start disagreeing about which months one URL shows; ADR-0001's addendum carries the
+argument and the test that licensed retiring the original `Date` arithmetic.
+
 The Month Axis is derived after filtering: one shared axis for every series, because Chart.js
 appends any label missing from `labels` to the end and a per-series axis scrambles the rest.
 
@@ -264,7 +270,8 @@ is a pointer file, so it cannot contradict anything.
 
 Of the seven ADRs, one is superseded and one is half-landed. 0003 deferred a `src/utils/`
 reorganisation; 0007 replaces its pause with a standing rule, and the reorg itself is now tracked
-in #170, blocked on the month migration. 0006's `month.ts` exists with a full spec and still no
-production caller — #144, #145 and #146 are the migration onto it, and they are the most actionable
-thing in this set. 0005 is done: #154 moved every consumer onto Line Readouts and #167 deleted the
+in #170, blocked on the month migration. 0006's `month.ts` now has its first production callers:
+both window rules are stated there and reached through the adapters in `src/ridership/`. #144, #145
+and #146 — the rest of the migration, moving the app's other month encodings onto `Month` — are
+still the most actionable thing in this set. 0005 is done: #154 moved every consumer onto Line Readouts and #167 deleted the
 write-back, so no `Line` carries a derived figure any more.

--- a/docs/architecture/diagrams.md
+++ b/docs/architecture/diagrams.md
@@ -819,6 +819,12 @@ This reads like an off-by-one and is not. It is long-standing behaviour, users h
 against it, and `e2e/chart-content.spec.ts` renders windows through it into committed PNG
 baselines, so normalising it would change what every existing link shows. ADR-0001 accepts it.
 
+Each rule is stated exactly once, in `utils/month.ts` — `containsOffset` and `contains` — and
+production reaches it through a `Date`-shaped adapter (`ridership/monthWindow.ts`,
+`ridership/eventWindow.ts`). Two copies of a rule this surprising is how the chart and the stop
+panel would start disagreeing about which months one URL shows; ADR-0001's addendum carries the
+argument and the test that licensed retiring the original `Date` arithmetic.
+
 The Month Axis is derived after filtering: one shared axis for every series, because Chart.js
 appends any label missing from `labels` to the end and a per-series axis scrambles the rest.
 
@@ -852,7 +858,7 @@ flowchart TB
     axisDef --> axisGap --> axisTwo
   end
 
-  onePlace["utils/month.ts — containsOffset() and contains()<br/>encode both rules once. Landed and tested;<br/>the production path still does Date arithmetic. ADR-0006"]
+  onePlace["utils/month.ts — containsOffset() and contains()<br/>state both rules once, and production goes through them.<br/>ridership/monthWindow.ts and ridership/eventWindow.ts are<br/>the Date-shaped adapters in front. ADR-0001 · ADR-0006"]
 
   choice --> monthWindow
   choice --> eventWindow
@@ -862,9 +868,7 @@ flowchart TB
   keep --> onePlace
 
   classDef cycle fill:#fbe0e1,stroke:#eb131b,stroke-width:1.5px,color:#44403c
-  classDef pending fill:#fdf2d6,stroke:#fdb913,stroke-width:1.5px,color:#44403c
   class keep cycle
-  class onePlace pending
 ```
 
 ---
@@ -1232,9 +1236,10 @@ is a pointer file, so it cannot contradict anything.
 
 Of the seven ADRs, one is superseded and one is half-landed. 0003 deferred a `src/utils/`
 reorganisation; 0007 replaces its pause with a standing rule, and the reorg itself is now tracked
-in #170, blocked on the month migration. 0006's `month.ts` exists with a full spec and still no
-production caller — #144, #145 and #146 are the migration onto it, and they are the most actionable
-thing in this set. 0005 is done: #154 moved every consumer onto Line Readouts and #167 deleted the
+in #170, blocked on the month migration. 0006's `month.ts` now has its first production callers:
+both window rules are stated there and reached through the adapters in `src/ridership/`. #144, #145
+and #146 — the rest of the migration, moving the app's other month encodings onto `Month` — are
+still the most actionable thing in this set. 0005 is done: #154 moved every consumer onto Line Readouts and #167 deleted the
 write-back, so no `Line` carries a derived figure any more.
 
 ```mermaid

--- a/docs/architecture/mermaid/13-month-windows.mmd
+++ b/docs/architecture/mermaid/13-month-windows.mmd
@@ -27,7 +27,7 @@ flowchart TB
     axisDef --> axisGap --> axisTwo
   end
 
-  onePlace["utils/month.ts — containsOffset() and contains()<br/>encode both rules once. Landed and tested;<br/>the production path still does Date arithmetic. ADR-0006"]
+  onePlace["utils/month.ts — containsOffset() and contains()<br/>state both rules once, and production goes through them.<br/>ridership/monthWindow.ts and ridership/eventWindow.ts are<br/>the Date-shaped adapters in front. ADR-0001 · ADR-0006"]
 
   choice --> monthWindow
   choice --> eventWindow
@@ -37,6 +37,4 @@ flowchart TB
   keep --> onePlace
 
   classDef cycle fill:#fbe0e1,stroke:#eb131b,stroke-width:1.5px,color:#44403c
-  classDef pending fill:#fdf2d6,stroke:#fdb913,stroke-width:1.5px,color:#44403c
   class keep cycle
-  class onePlace pending

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -10,9 +10,14 @@ npm run test        # run all tests once
 npm run test:watch  # watch mode
 ```
 
-Vitest with `@testing-library/react`, jsdom, globals enabled — no per-file imports of
-`describe`/`it`/`expect`. Specs live next to the code under `src/`. `vitest.config.ts` excludes
-`e2e/**` (Playwright's) and `.claude/**` (throwaway worktrees).
+Vitest with `@testing-library/react`, jsdom. Specs live next to the code under `src/`.
+`vitest.config.ts` excludes `e2e/**` (Playwright's) and `.claude/**` (throwaway worktrees).
+
+**Import `describe`/`it`/`expect` from `vitest` in every spec.** `vitest.config.ts` does set
+`globals: true`, so the runtime would not need them — but `tsconfig.app.json` does not list
+`vitest/globals` under `types`, so `tsc -b` cannot see them and `npm run build` fails on a spec
+that omits the import. Runtime globals and type-level globals are separate switches and only one
+is on.
 
 One file:
 

--- a/src/ridership/buildRidershipView.ts
+++ b/src/ridership/buildRidershipView.ts
@@ -7,6 +7,7 @@ import {
   type LineCoverage,
 } from './chartData';
 import { lineMetrics, type LineMetrics } from './lineMetrics';
+import { isInEventWindow } from './eventWindow';
 import { isInMonthWindow } from './monthWindow';
 import { getLineColor, getLineNames } from '../utils/lines';
 import transitEventsData from '../data/transit-events.json';
@@ -197,8 +198,9 @@ export function buildRidershipView(input: RidershipViewInput): RidershipView {
   const allEvents = inputEvents ?? (transitEventsData as TransitEvent[]);
 
   /**
-   * The Event Window: inclusive on both ends and 1-based, unlike the Month
-   * Window above. Preserve the disagreement.
+   * The Event Window predicate is `isInEventWindow` and is inclusive on both ends,
+   * unlike the Month Window above — see `./eventWindow`. The disagreement is
+   * deliberate; do not restate either rule here.
    *
    * The selection set here reads the **live** selection (`lines.filter(l =>
    * l.selected)`), not the Selection Snapshot the datasets filter on. That is
@@ -211,14 +213,10 @@ export function buildRidershipView(input: RidershipViewInput): RidershipView {
   const selectedLineIds = new Set(
     lines.filter((l) => l.selected).map((l) => l.id),
   );
-  const startYYYYMM = startDate.getFullYear() * 100 + (startDate.getMonth() + 1);
-  const endYYYYMM = endDate.getFullYear() * 100 + (endDate.getMonth() + 1);
 
   const events = allEvents
     .filter((event) => {
-      const [year, month] = event.date.split('-').map(Number);
-      const eventYYYYMM = year * 100 + month;
-      if (eventYYYYMM < startYYYYMM || eventYYYYMM > endYYYYMM) return false;
+      if (!isInEventWindow(event, startDate, endDate)) return false;
       if (event.line_ids.length === 0) return true;
       return event.line_ids.some((id) => selectedLineIds.has(id));
     })

--- a/src/ridership/eventWindow.test.ts
+++ b/src/ridership/eventWindow.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { isInEventWindow } from './eventWindow';
+import { isInMonthWindow } from './monthWindow';
+import { contains } from '../utils/month';
+
+/**
+ * Boundary tests for the Event Window rule, pinned at month granularity — the sibling
+ * of `monthWindow.test.ts`, and deliberately not the same rule.
+ *
+ * Bounds are constructed the way the app constructs them, `new Date(year, month - 1)`,
+ * and event dates the way `transit-events.json` stores them, `"YYYY-MM"`.
+ */
+const bound = (year: number, month: number) => new Date(year, month - 1);
+
+// The window the chart's date pickers produce for "Jan 2020 – Dec 2020".
+const start = bound(2020, 1);
+const end = bound(2020, 12);
+
+const event = (date: string) => ({ date });
+
+describe('isInEventWindow — the Event Window rule, S <= R <= E', () => {
+  it('includes the start month', () => {
+    expect(isInEventWindow(event('2020-01'), start, end)).toBe(true);
+  });
+
+  it('excludes the month before the start month', () => {
+    expect(isInEventWindow(event('2019-12'), start, end)).toBe(false);
+  });
+
+  it('includes the end month — both ends are in', () => {
+    expect(isInEventWindow(event('2020-12'), start, end)).toBe(true);
+  });
+
+  it('excludes the month after the end month', () => {
+    expect(isInEventWindow(event('2021-01'), start, end)).toBe(false);
+  });
+
+  it('includes a single-month window at its one month', () => {
+    const point = bound(2020, 6);
+    expect(isInEventWindow(event('2020-06'), point, point)).toBe(true);
+    expect(isInEventWindow(event('2020-05'), point, point)).toBe(false);
+    expect(isInEventWindow(event('2020-07'), point, point)).toBe(false);
+  });
+
+  describe('across a year boundary', () => {
+    const crossStart = bound(2019, 11);
+    const crossEnd = bound(2020, 3);
+
+    it('includes every month from the start to the end inclusive', () => {
+      for (const date of ['2019-11', '2019-12', '2020-01', '2020-02', '2020-03'])
+        expect(isInEventWindow(event(date), crossStart, crossEnd)).toBe(true);
+    });
+
+    it('excludes the months either side', () => {
+      expect(isInEventWindow(event('2019-10'), crossStart, crossEnd)).toBe(
+        false,
+      );
+      expect(isInEventWindow(event('2020-04'), crossStart, crossEnd)).toBe(
+        false,
+      );
+    });
+  });
+
+  /**
+   * The disagreement with the Month Window is the whole reason both rules exist. For
+   * one window, the context log runs two months past the chart's right-hand edge: the
+   * chart's last plotted month is `E - 2`, and events at `E - 1` and `E` still show.
+   *
+   * ADR-0001: reconciling the two would change which events a shared URL displays.
+   */
+  it('disagrees with the Month Window at E and E - 1, deliberately', () => {
+    // E - 1
+    expect(isInEventWindow(event('2020-11'), start, end)).toBe(true);
+    expect(isInMonthWindow({ year: 2020, month: 11 }, start, end)).toBe(false);
+
+    // E
+    expect(isInEventWindow(event('2020-12'), start, end)).toBe(true);
+    expect(isInMonthWindow({ year: 2020, month: 12 }, start, end)).toBe(false);
+
+    // Everywhere else in the window they agree.
+    expect(isInEventWindow(event('2020-05'), start, end)).toBe(true);
+    expect(isInMonthWindow({ year: 2020, month: 5 }, start, end)).toBe(true);
+  });
+
+  it('excludes an unparseable date rather than admitting it to every window', () => {
+    // `transit-events.json` is schema-checked, so this should be unreachable. The
+    // failure mode being guarded is the old inline `YYYYMM` compare's: `Number("xx")`
+    // is `NaN`, every comparison against it is false, and the event fell through into
+    // the log for *every* window instead of none.
+    expect(isInEventWindow(event('not-a-month'), start, end)).toBe(false);
+    expect(isInEventWindow(event('2020'), start, end)).toBe(false);
+    expect(isInEventWindow(event(''), start, end)).toBe(false);
+  });
+
+  /**
+   * The same exhaustive check `monthWindow.test.ts` runs, for the same reason: the
+   * hand-written cases above pin the boundaries, and this pins that the `Date`-and-text
+   * adapter never disagrees with the rule it wraps, over every window in a decade.
+   */
+  it('agrees with `contains` over a decade of windows, exhaustively', () => {
+    const months = [];
+    for (let year = 2018; year <= 2027; year++)
+      for (let month = 1; month <= 12; month++) months.push({ year, month });
+    const bounds = months.map((m) => bound(m.year, m.month));
+    const dates = months.map(
+      (m) => `${m.year}-${String(m.month).padStart(2, '0')}`,
+    );
+
+    let compared = 0;
+    for (const [s, start] of months.entries())
+      for (const [e, end] of months.entries())
+        for (const [i, m] of months.entries()) {
+          const live = isInEventWindow({ date: dates[i] }, bounds[s], bounds[e]);
+          const byOrdinal = contains({ start, end }, m);
+          if (live !== byOrdinal)
+            throw new Error(
+              `disagree at start=${start.year}-${start.month} end=${end.year}-${end.month} event=${dates[i]}: adapter says ${String(live)}, rule says ${String(byOrdinal)}`,
+            );
+          compared++;
+        }
+
+    expect(compared).toBe(months.length ** 3);
+  });
+});

--- a/src/ridership/eventWindow.ts
+++ b/src/ridership/eventWindow.ts
@@ -1,0 +1,45 @@
+import { contains, monthOf, parseMonth, type Month } from '../utils/month';
+
+/**
+ * The Event Window predicate — the one copy.
+ *
+ * ## The Event Window is inclusive, and disagrees with the Month Window on purpose
+ *
+ * An event dated at calendar-month ordinal `R` is included when `S <= R <= E`. Both
+ * ends are in. The Month Window over the *same* two dates excludes `E` and `E - 1`
+ * (see `./monthWindow`), so for any given URL the context log runs two months past
+ * the right-hand edge of the chart. That is the behaviour the app has always had;
+ * reconciling the two would change which events a shared URL shows, and
+ * `e2e/context-logs.spec.ts` pins it into committed PNG baselines. See
+ * `docs/adr/0001-ridership-month-window-is-deliberately-offset.md`.
+ *
+ * **Callers must not restate this.** It was inline in `buildRidershipView` as a
+ * `YYYYMM` integer comparison while `src/utils/month.ts` stated the same rule a second
+ * time as `contains` — the same fork shape ADR-0001 exists to prevent, one rule over
+ * from the one it was written about. This function is the `Date`-and-`"YYYY-MM"`
+ * adapter in front of `contains`, and `contains` is the rule.
+ *
+ * Like `isInMonthWindow`, this **assumes month-aligned bounds** — `new Date(y, m - 1)`,
+ * midnight on the first. Every producer in the app is; a bound carrying a day or a
+ * time would be truncated to its month here.
+ *
+ * A malformed `date` is excluded. `transit-events.json` is schema-checked so this
+ * should be unreachable, but the alternative — treating an unparseable month as
+ * inside every window — would put a broken event in every context log.
+ */
+export function isInEventWindow(
+  event: { date: string },
+  startDate: Date,
+  endDate: Date,
+): boolean {
+  const month = parseMonth(event.date);
+  if (!month) return false;
+  return contains(
+    { start: boundToMonth(startDate), end: boundToMonth(endDate) },
+    month,
+  );
+}
+
+/** A month-aligned window bound as the month it names. `Date`'s month is 0-based. */
+const boundToMonth = (bound: Date): Month =>
+  monthOf(bound.getFullYear(), bound.getMonth() + 1);

--- a/src/ridership/index.ts
+++ b/src/ridership/index.ts
@@ -25,6 +25,14 @@ export {
 export { isInMonthWindow } from './monthWindow';
 
 /**
+ * The Event Window predicate, exported for the same reason and under the same
+ * condition: one copy, and callers apply it rather than restating it. It is inclusive
+ * on both ends where the Month Window is not, so the context log deliberately runs two
+ * months past the chart's right-hand edge — see `./eventWindow` and ADR-0001.
+ */
+export { isInEventWindow } from './eventWindow';
+
+/**
  * The line-table's month axis and coverage labels.
  *
  * `buildRidershipView` cannot serve these: it derives everything for the **chart**,

--- a/src/ridership/monthWindow.test.ts
+++ b/src/ridership/monthWindow.test.ts
@@ -88,18 +88,46 @@ describe('isInMonthWindow — the Month Window rule, S <= R <= E - 2', () => {
   });
 
   /**
-   * `src/utils/month.ts`'s `containsOffset` states this rule a second time, in ordinal
-   * form, and is the landing site for the month migration ADR-0007 tracks as #144 /
-   * #145 / #146. ADR-0001 is explicit that "a `Month` module that unifies the app's
-   * several month encodings **may** replace the arithmetic; it **may not** change these
-   * boundaries" — and that the tests, not the algebra, are what makes that safe.
+   * The `Date` comparison `isInMonthWindow` used to be, kept here **verbatim** as the
+   * historical reference. Nothing in `src/` calls it and nothing should — it exists so
+   * the rule that shipped for years stays executable and can be asserted against.
    *
-   * Two functions each asserted against their own hand-written cases does not establish
-   * that. This does: every month from 2018 through 2027 against every window with
-   * endpoints in the same span, both functions, exhaustively. If the migration ever
-   * moves a boundary, this fails before anything reaches a chart baseline.
+   * `new Date(year, month)` treats `month` as 0-based while the data stores it 1-based,
+   * and the bounds are built as `new Date(year, month - 1)`; the strict comparison on
+   * both ends is what produces the offset.
    */
-  it('agrees with `containsOffset` over a decade of windows, exhaustively', () => {
+  const legacyIsInMonthWindow = (
+    record: { year: number; month: number },
+    startDate: Date,
+    endDate: Date,
+  ): boolean => {
+    const metricDate = new Date(record.year, record.month);
+    if (
+      startDate.getTime() >= metricDate.getTime() ||
+      endDate.getTime() <= metricDate.getTime()
+    )
+      return false;
+    return true;
+  };
+
+  /**
+   * ADR-0001 is explicit that "a `Month` module that unifies the app's several month
+   * encodings **may** replace the arithmetic; it **may not** change these boundaries" —
+   * and that the tests, not the algebra, are what makes that safe. This is that test,
+   * and it is what licensed `isInMonthWindow` to stop being the `Date` comparison and
+   * start delegating to `containsOffset`.
+   *
+   * Hand-written cases on each side do not establish equivalence. This does: every
+   * month from 2018 through 2027 against every window with endpoints in the same span,
+   * exhaustively, three ways — the live function, the ordinal rule it delegates to, and
+   * the `Date` arithmetic it replaced.
+   *
+   * The third comparand is the point. Now that `isInMonthWindow` calls `containsOffset`,
+   * checking those two against each other alone would be a tautology that passes no
+   * matter what either does. `legacyIsInMonthWindow` is the only comparand here that
+   * cannot move, so it is the one holding the boundaries still.
+   */
+  it('agrees with `containsOffset` and the retired `Date` arithmetic over a decade of windows, exhaustively', () => {
     const months = [];
     for (let year = 2018; year <= 2027; year++)
       for (let month = 1; month <= 12; month++) months.push({ year, month });
@@ -111,11 +139,12 @@ describe('isInMonthWindow — the Month Window rule, S <= R <= E - 2', () => {
     for (const [s, start] of months.entries())
       for (const [e, end] of months.entries())
         for (const m of months) {
-          const byDate = isInMonthWindow(m, bounds[s], bounds[e]);
+          const live = isInMonthWindow(m, bounds[s], bounds[e]);
           const byOrdinal = containsOffset({ start, end }, m);
-          if (byDate !== byOrdinal)
+          const byDate = legacyIsInMonthWindow(m, bounds[s], bounds[e]);
+          if (live !== byOrdinal || live !== byDate)
             throw new Error(
-              `disagree at start=${start.year}-${start.month} end=${end.year}-${end.month} record=${m.year}-${m.month}: Date says ${String(byDate)}, ordinal says ${String(byOrdinal)}`,
+              `disagree at start=${start.year}-${start.month} end=${end.year}-${end.month} record=${m.year}-${m.month}: live says ${String(live)}, ordinal says ${String(byOrdinal)}, retired Date arithmetic says ${String(byDate)}`,
             );
           compared++;
         }

--- a/src/ridership/monthWindow.ts
+++ b/src/ridership/monthWindow.ts
@@ -1,3 +1,5 @@
+import { containsOffset, monthOf, type Month } from '../utils/month';
+
 /**
  * The Month Window predicate — the one copy.
  *
@@ -6,39 +8,50 @@
  * A record at calendar-month ordinal `R` is included when `S <= R <= E - 2`: the
  * start month is included, and **the end month and the month immediately before it
  * are excluded**. This is intended, not an off-by-one bug — the app has always
- * behaved this way, users have shared URLs against it, and
- * `e2e/chart-content.spec.ts` renders windows through it into committed PNG
- * baselines. See
+ * behaved this way and `e2e/chart-content.spec.ts` renders windows through it into
+ * committed PNG baselines. See
  * `docs/adr/0001-ridership-month-window-is-deliberately-offset.md`.
  *
- * The `Date` arithmetic below is the original comparison **verbatim** rather than
- * restated as an ordinal comparison, precisely so it cannot drift. `new Date(year,
- * month)` treats `month` as 0-based while the data stores it 1-based, and the window
- * bounds are built as `new Date(year, month - 1)`; the strict comparison on both ends
- * is what produces the offset. ADR-0001 records why copy-paste beat algebra here:
- * copy-paste is provably non-drifting, algebra is only provably equivalent if the
- * algebra is right.
+ * **Callers must not restate this.** It has two derivations — the chart's Ridership
+ * View and the stop panel's Stop View — and if either restated it the two panels
+ * would disagree about which months are on screen for the same URL.
  *
- * **Callers must not restate this.** It has two derivations now — the chart's
- * Ridership View and the stop panel's Stop View — and if either restated it the two
- * panels would disagree about which months are on screen for the same URL.
+ * ## Why this is now ordinal arithmetic and not the original `Date` comparison
  *
- * Note `src/utils/month.ts` states the same rule a second time as `containsOffset`,
- * over `Month`/`MonthWindow` ordinals. That is not a fork: it has no production
- * caller and is the landing site for the month migration ADR-0007 tracks as #144 /
- * #145 / #146, whose whole point is to replace this arithmetic without changing these
- * boundaries. Until that migration lands, production goes through this function.
+ * The rule used to be written here as the `Date` comparison it was extracted from,
+ * verbatim, on the argument that copy-paste is provably non-drifting where algebra is
+ * only provably equivalent if the algebra is right. That held while there was nowhere
+ * else for the rule to live. It stopped holding once `src/utils/month.ts` grew
+ * `containsOffset` — a *second* statement of the same rule, over `Month` ordinals.
+ * Two statements is the fork ADR-0001 exists to prevent, whichever one production
+ * happens to call.
+ *
+ * So this delegates. `containsOffset` is the one statement of the rule; this function
+ * is the `Date`-shaped adapter in front of it, and it is what ADR-0006 meant by
+ * licensing a replacement of the arithmetic that does not move the boundaries. What
+ * makes the replacement safe is not the derivation but
+ * `monthWindow.test.ts`'s exhaustive case, which runs both forms over every window
+ * pair in a decade and requires they agree record for record.
+ *
+ * **This adapter assumes the bounds are month-aligned** — `new Date(y, m - 1)`,
+ * midnight on the first. Every producer is: `parseMonthParam`, `DefaultStartDate`,
+ * `dataDefaultEndDate`, the chart drag's `labelToDate`, and `DateRangeSelector`,
+ * which mutates an already-aligned date with `setMonth`/`setFullYear` only. A bound
+ * carrying a day or a time would compare differently here than under the old
+ * timestamp comparison, so a new producer must keep to that shape. ADR-0006 is the
+ * standing argument for why bounds should not be `Date`s at all.
  */
 export function isInMonthWindow(
   record: { year: number; month: number },
   startDate: Date,
   endDate: Date,
 ): boolean {
-  const metricDate = new Date(record.year, record.month);
-  if (
-    startDate.getTime() >= metricDate.getTime() ||
-    endDate.getTime() <= metricDate.getTime()
-  )
-    return false;
-  return true;
+  return containsOffset(
+    { start: boundToMonth(startDate), end: boundToMonth(endDate) },
+    record,
+  );
 }
+
+/** A month-aligned window bound as the month it names. `Date`'s month is 0-based. */
+const boundToMonth = (bound: Date): Month =>
+  monthOf(bound.getFullYear(), bound.getMonth() + 1);

--- a/src/utils/dataDateRange.ts
+++ b/src/utils/dataDateRange.ts
@@ -14,10 +14,14 @@ export const dataMaxYear: number = maxYear;
 /**
  * Default end of the date window.
  *
- * App.tsx filters with `new Date(record.year, record.month)` — month is 1-based
- * in the data but Date treats it as 0-based, and the end comparison is exclusive
- * (`endDate <= metricDate` skips the record). To include the latest record we
- * therefore set the default one month past it. This preserves the intentional
- * off-by-one (see CLAUDE.md); do not "fix" the filter.
+ * The Month Window excludes the end month **and the month before it** — the rule is
+ * `isInMonthWindow` in `src/ridership/monthWindow.ts`, and it is deliberate. To include
+ * the latest record in the default view we therefore set the default end one month past
+ * it. See `docs/adr/0001-ridership-month-window-is-deliberately-offset.md`; do not
+ * "fix" the filter.
+ *
+ * This bound must stay **month-aligned** — `new Date(y, m)`, midnight on the first —
+ * like every other producer of a window bound. `isInMonthWindow` reads only the year
+ * and month off it.
  */
 export const dataDefaultEndDate: Date = new Date(maxYear, maxMonth + 1);

--- a/src/utils/month.ts
+++ b/src/utils/month.ts
@@ -83,6 +83,10 @@ export const displayMonth = (m: Month): string =>
  * This is the **Event Window** rule (`CONTEXT.md`). It deliberately disagrees with
  * `containsOffset` below, which applies to the same window. Reconciling them would
  * change which events appear for a given URL — see ADR-0001.
+ *
+ * The one statement of the rule. Production reaches it through
+ * `src/ridership/eventWindow.ts`, which adapts the `Date` bounds and the `"YYYY-MM"`
+ * event date the context log actually carries. Do not restate it at a call site.
  */
 export function contains(w: MonthWindow, m: Month): boolean {
   const r = ordinal(m);
@@ -103,6 +107,13 @@ export function contains(w: MonthWindow, m: Month): boolean {
  * comparison `start < record < end` is `S < R + 1 < E`, i.e. `S <= R <= E - 2`. The
  * boundary tests in `month.test.ts`, not this derivation, are what make that safe;
  * ADR-0006 carries the working.
+ *
+ * The one statement of the rule. Production reaches it through
+ * `src/ridership/monthWindow.ts`, which adapts the `Date` bounds; both the chart's
+ * Ridership View and the stop panel's Stop View filter through that adapter.
+ * `monthWindow.test.ts` runs the two forms against each other over every window pair
+ * in a decade, which is what let the `Date` arithmetic be retired. Do not restate this
+ * at a call site.
  */
 export function containsOffset(w: MonthWindow, m: Month): boolean {
   const r = ordinal(m);


### PR DESCRIPTION
Follow-up to [#180](https://github.com/streetsforall/metro_ridership_app/pull/180). Nothing on screen changes.

## The problem

The app has two rules for "which months are inside the date range you picked":

- **Month Window** — for the chart. The last two months of your range are excluded. This looks like a bug and isn't ([ADR-0001](docs/adr/0001-ridership-month-window-is-deliberately-offset.md)); screenshot tests are pinned to it.
- **Event Window** — for the context log. An ordinary inclusive range.

Each rule was written down in **two** places. `src/utils/month.ts` had a clean version of both — but nothing called them, so the real filtering happened elsewhere, in a copy. Two copies of a rule this surprising is how the chart and the stop panel end up showing different months for the same URL.

## The fix

One copy of each rule, and everything calls it:

| rule | lives in | called through |
| --- | --- | --- |
| Month Window | `month.ts` → `containsOffset` | `ridership/monthWindow.ts` |
| Event Window | `month.ts` → `contains` | `ridership/eventWindow.ts` |

The two middle files are thin adapters. The app hands around `Date` objects and the rules work in plain year-and-month, so the adapter converts and calls the rule. That's all they do.

The two windows still disagree by two months, on purpose. There's now a test pinning that disagreement instead of a comment describing it.

## What a reviewer should look at

**The proof that nothing changed.** `monthWindow.test.ts` runs the new code against the old code over every possible date range in a decade and requires they agree every time. To make that possible the old version is kept inside the test file — the new code now calls the shared rule, so comparing it to that rule alone would prove nothing.

**One real behaviour change.** A malformed event date used to slip into *every* date range (`Number("xx")` is `NaN`, and every comparison against `NaN` is false). Now it's excluded. The events file is schema-checked so this shouldn't be reachable, but it is a difference.

**Bundle size.** Entry `+160 B`, the lazy `OutputArea` chunk `+210 B` — the adapters. #180 kept that chunk byte-identical; this doesn't.

## Checks

| | |
| --- | --- |
| `npm run test` | 802 passed (792 before, +10 new) |
| `npm run lint` | clean |
| `npm run build` | clean |
| Screenshot tests | **0 of 80 baselines changed** |
| `buildRidershipView.test.ts`, `month.test.ts` | pass **unedited** |

One caveat: the first full screenshot run exited 1 with most specs unrun; a clean re-run on an untouched tree went green. Couldn't reproduce it. Worth watching CI.

## Also fixed — the two loose ends #180 flagged

- `src/utils/dataDateRange.ts` said the date filter lives in `App.tsx`. It hasn't for a while.
- `CLAUDE.md` and `docs/guides/testing.md` said test files don't need to import `describe`/`it`/`expect`. They do — `vitest` provides them at runtime, but TypeScript doesn't know that, so `npm run build` fails without them.

Docs: ADR-0001 gets an addendum (not a rewrite), the `13-month-windows` diagram drops its now-false caveat, and ROADMAP risk #1 "Forking the Month Window" is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
