### PR TITLE
fix(context-log): a pin marks a row, it never moves the panel

### DIFF
--- a/src/components/ContextLogPanel.tsx
+++ b/src/components/ContextLogPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import type { TransitEvent } from '../@types/events.types';
 import {
   categoryChip,
@@ -10,7 +10,7 @@ import {
 
 export interface ContextLogPanelProps {
   events: TransitEvent[];
-  /** Pinned month label (`"YYYY M"`); its rows are highlighted and scrolled to. */
+  /** Pinned month label (`"YYYY M"`); its rows are highlighted where they sit. */
   pinnedMonth: string | null;
   /** Clicking a row pins its month on the chart. */
   onSelectMonth: (month: string) => void;
@@ -23,8 +23,8 @@ export interface ContextLogPanelProps {
  *
  * The rows and the chart's dots are two views of one set, so each row is a
  * button: hovering it enlarges its dot, clicking it pins that month's tooltip,
- * and pinning a dot on the chart highlights and scrolls to the row here. Without
- * that pairing the panel is a second, unrelated list that happens to share data.
+ * and pinning a dot on the chart marks the row here. Without that pairing the
+ * panel is a second, unrelated list that happens to share data.
  */
 export default function ContextLogPanel({
   events,
@@ -32,24 +32,17 @@ export default function ContextLogPanel({
   onSelectMonth,
   onHoverMonthChange,
 }: ContextLogPanelProps) {
+  // A pin marks; it does not move. Pinning used to force this panel open and
+  // scroll the matching row into view, which took a reader part-way down the log
+  // somewhere they had not asked to go, from a gesture made on the chart. Open
+  // state and scroll position belong to the reader, so both effects are gone.
+  //
+  // The consequence is deliberate, not an oversight: pin a Month from the chart
+  // while this panel is collapsed and the highlighted row is off-screen with no
+  // cue that it exists. The tooltip carries the event content in full, so the
+  // panel is a second view of it rather than the only one, and a reader who shut
+  // the panel loses nothing by it staying shut. Don't add a substitute cue here.
   const [isOpen, setIsOpen] = useState(true);
-  const rowRefs = useRef(new Map<string, HTMLLIElement>());
-
-  // Pinning a month on the chart reveals its entry, rather than highlighting a
-  // row inside a collapsed panel where nobody can see it.
-  useEffect(() => {
-    if (pinnedMonth === null) return;
-    setIsOpen(true);
-  }, [pinnedMonth]);
-
-  useEffect(() => {
-    if (pinnedMonth === null || !isOpen) return;
-    const pinned = events.find(
-      (event) => eventDateToLabel(event.date) === pinnedMonth,
-    );
-    if (!pinned) return;
-    rowRefs.current.get(pinned.id)?.scrollIntoView?.({ block: 'nearest' });
-  }, [pinnedMonth, isOpen, events]);
 
   return (
     <div className="pane" id="context-log-panel">
@@ -68,10 +61,7 @@ export default function ContextLogPanel({
        * chart and map above it unreachable without scrolling back.
        *
        * The cap is on the `<ol>` and not on the `.pane`, which keeps the
-       * collapse toggle in view while the rows move under it. It also gives the
-       * pin's `scrollIntoView({ block: 'nearest' })` below a scroll container of
-       * its own, so revealing a pinned row scrolls the list instead of jumping
-       * the whole page.
+       * collapse toggle in view while the rows move under it.
        */}
       {isOpen && (
         <ol className="flex flex-col gap-3 mt-3 max-h-[32rem] overflow-y-auto">
@@ -87,10 +77,6 @@ export default function ContextLogPanel({
                  deliberately close, and the label is what tells them apart. */
               <li
                 key={event.id}
-                ref={(node) => {
-                  if (node) rowRefs.current.set(event.id, node);
-                  else rowRefs.current.delete(event.id);
-                }}
                 className="border-l-2 pl-3"
                 style={{ borderColor: categoryColor(event.category) }}
               >

--- a/src/components/__tests__/ContextLogPanel.test.tsx
+++ b/src/components/__tests__/ContextLogPanel.test.tsx
@@ -215,10 +215,33 @@ describe('chart → ContextLogPanel', () => {
    * the cost of marking a row nobody can see, which the tooltip covers.
    */
   it('does not scroll any row into view when a month is pinned', () => {
+    // jsdom implements no `scrollIntoView`, so it has to be assigned onto the
+    // prototype rather than spied on — and put back afterwards. The assertion
+    // is a negative one, and a stub left on `Element.prototype` would arm every
+    // test declared after this one against a call it never made.
+    // Kept as a descriptor rather than a plain reference, which is both how you
+    // put an absent method back and what keeps `@typescript-eslint/unbound-method`
+    // quiet.
+    const original = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      'scrollIntoView',
+    );
     const scrollIntoView = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoView;
-    renderPanel([opening, closure], { pinnedMonth: '2019 5' });
-    expect(scrollIntoView).not.toHaveBeenCalled();
+    try {
+      renderPanel([opening, closure], { pinnedMonth: '2019 5' });
+      // The pinned month is the second row's, and the panel opens by default —
+      // so this fixture did scroll before the change, and a render that dropped
+      // the rows cannot be what makes the assertion below pass.
+      expect(screen.getByRole('button', { name: /New Blue/ })).toBeTruthy();
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    } finally {
+      if (original) {
+        Object.defineProperty(Element.prototype, 'scrollIntoView', original);
+      } else {
+        delete (Element.prototype as Partial<Element>).scrollIntoView;
+      }
+    }
   });
 
   it('leaves a collapsed panel collapsed when a month is pinned', () => {

--- a/src/components/__tests__/ContextLogPanel.test.tsx
+++ b/src/components/__tests__/ContextLogPanel.test.tsx
@@ -209,18 +209,19 @@ describe('chart → ContextLogPanel', () => {
     ).toContain('ring-2');
   });
 
-  it('scrolls the pinned row into view', () => {
+  /**
+   * A pin marks; it does not move. The panel's open state and scroll position
+   * belong to the reader, so a pin taken on the chart changes neither — even at
+   * the cost of marking a row nobody can see, which the tooltip covers.
+   */
+  it('does not scroll any row into view when a month is pinned', () => {
     const scrollIntoView = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoView;
     renderPanel([opening, closure], { pinnedMonth: '2019 5' });
-    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 
-  /**
-   * Highlighting a row inside a collapsed panel highlights nothing, so a pin
-   * from the chart reopens it.
-   */
-  it('reopens a collapsed panel when a month is pinned', () => {
+  it('leaves a collapsed panel collapsed when a month is pinned', () => {
     const { rerender } = renderPanel([opening], { pinnedMonth: null });
     fireEvent.click(screen.getByRole('button', { name: /context logs/i }));
     expect(screen.queryByText('Regional Connector Opening')).toBeNull();
@@ -233,7 +234,26 @@ describe('chart → ContextLogPanel', () => {
         onHoverMonthChange={vi.fn()}
       />,
     );
-    expect(screen.getByText('Regional Connector Opening')).toBeTruthy();
+    expect(screen.queryByText('Regional Connector Opening')).toBeNull();
+  });
+
+  /** The mark is on the row whether or not the reader can see it. */
+  it('still marks the pinned row after the panel is reopened by hand', () => {
+    const { rerender } = renderPanel([opening], { pinnedMonth: null });
+    fireEvent.click(screen.getByRole('button', { name: /context logs/i }));
+
+    rerender(
+      <ContextLogPanel
+        events={[opening]}
+        pinnedMonth="2023 2"
+        onSelectMonth={vi.fn()}
+        onHoverMonthChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /context logs/i }));
+    expect(
+      screen.getByRole('button', { name: /Regional Connector/ }).getAttribute('aria-pressed'),
+    ).toBe('true');
   });
 
   it('leaves the panel alone when the pinned month has no entry', () => {

--- a/src/components/__tests__/OutputArea.test.tsx
+++ b/src/components/__tests__/OutputArea.test.tsx
@@ -218,6 +218,20 @@ describe('chart ↔ context log', () => {
     });
     expect(logRow().getAttribute('aria-pressed')).toBe('true');
   });
+
+  /**
+   * A pin marks; it does not move. Pinning from the chart leaves the panel where
+   * the reader left it, collapsed included — so the row it marks may not be on
+   * screen at all. The tooltip carries the event content, so that costs nothing.
+   */
+  it('leaves the panel collapsed when the chart pins a month', () => {
+    renderWithEvents();
+    fireEvent.click(screen.getByRole('button', { name: /context logs/i }));
+    act(() => {
+      chartProps?.onPinnedMonthChange('2023 2');
+    });
+    expect(screen.queryByText('Regional Connector Opening')).toBeNull();
+  });
 });
 
 /**


### PR DESCRIPTION
Closes #200. Parent spec #196, item 5.

## What changed

Pinning a Month force-opened the context-log panel and scrolled its matching row into view. A reader part-way down the log was moved somewhere else by a gesture made on the chart. Both effects are gone — open state and scroll position belong to the reader.

- `ContextLogPanel.tsx` — two `useEffect`s deleted: the one that set `isOpen` on a pin, and the one that called `scrollIntoView({ block: 'nearest' })` on the matching row.
- `rowRefs` and the `<li ref={…}>` callback go with them. The scroll was their only reader, so nothing else needed the node handles.
- `useEffect` / `useRef` imports drop; `useState` stays for the manual toggle.

Unchanged: the manual collapse toggle, the ordering, the row content, the `aria-pressed` mark on the pinned row, the category rule and chip, the `max-h-[32rem]` scroll cap on the `<ol>`.

## The off-screen row is deliberate

Pin a Month from the chart while the panel is collapsed → the marked row is not visible and nothing says it exists. That is the accepted cost, recorded as a comment where the effects used to be, including an instruction not to add a substitute cue. The tooltip carries the event content in full, so the panel is a second view of it rather than the only one.

## Tests

Deleted rather than adjusted, per the issue:

- `scrolls the pinned row into view`
- `reopens a collapsed panel when a month is pinned`

Replaced by:

- `does not scroll any row into view when a month is pinned` — same fixture, inverted assertion
- `leaves a collapsed panel collapsed when a month is pinned`
- `still marks the pinned row after the panel is reopened by hand` — the mark survives the panel being shut and reopened
- `leaves the panel collapsed when the chart pins a month` (OutputArea) — the shared seam the parent spec names, driving `onPinnedMonthChange` from the mocked chart

`npm run lint` clean · `npm run build` clean · `npx vitest run` → 837 passed, 34 files.

## Notes for review

- **No screenshot.** The change is the absence of movement; the only capturable state is a collapsed panel that stays collapsed, which is what it already looks like before a pin. Nothing in the rendered output differs.
- **No visual baselines touched.** This is the interaction half of #196, which by design moves no baselines.
- **One test lands in `OutputArea.test.tsx`,** which #199 (release-first pinning) also edits. Rebased on `origin/main` at 1d9d8ea; #199 had not landed at that point. If it lands first, this is an append inside the existing `chart ↔ context log` describe and should merge cleanly, but the output-area specs are worth a re-run.
## Review

`/code-review` run on the branch. One confirmed defect, fixed in be1c06e; everything else was a judgement call and is left here rather than acted on.

**Fixed** — the `Element.prototype.scrollIntoView` stub was assigned and never removed. Inherited from the deleted test, where a positive assertion made the leak harmless; with the assertion inverted to `not.toHaveBeenCalled()` a stub left behind arms every later test in the file against a call it never made. Now saved and restored as a property descriptor — jsdom implements no `scrollIntoView`, so a descriptor is the only way to put the absent method back, and it also avoids `@typescript-eslint/unbound-method`. The same commit strengthens the negative assertion by checking the pinned row rendered, so an empty render cannot be what makes it pass.

**Left for the reviewer:**

- **No ADR.** #196 says the "a pin marks; it does not move" principle and the release-first pin rule are "recorded together as one architecture decision". Release-first is #199, so the ADR spans both sub-issues and writing half of it here would leave a stub for #199 to rewrite. Deliberately not written; worth confirming it isn't dropped by both.
- **The intent comment is ten lines above a one-line `useState`.** In keeping with the file's voice, and the issue asks for the record to live exactly there. The first paragraph is history the commit message also carries — trim it if that reads as too much.
- **The `rerender(<ContextLogPanel … />)` block appears twice** in adjacent tests and `renderPanel` already returns `rerender`. Extractable into a `rerenderPanel` helper; left alone because the two tests read more plainly with the props visible.
- **`prettier --check` warns on all three files** — it warns identically on their merge-base versions. Pre-existing CRLF noise, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
