### PR TITLE
docs(glossary): Pinned Month and Range Selection, plus ADR-0011 on what a pin may do

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,9 +61,10 @@ _Avoid_: selected month, active month, focused month, sticky tooltip
 The drag across the plot that sets the Month Window, and the band drawn while that drag is in
 progress. It begins only once the pointer has travelled far enough for the gesture to be a drag
 rather than a click, so a plain click pins a Month and paints nothing. Deliberately mouse-only: a
-horizontal drag across a chart is how a page is scrolled on a phone.
-_Avoid_: sliding window, brush, drag window, range window — *window* already belongs to the Month
-Window and the Event Window, and a third sense of it makes all three ambiguous
+horizontal drag across a chart is how a page is scrolled on a phone. **Never named with *window*** —
+that word already belongs to the Month Window and the Event Window, and a third sense of it makes
+all three ambiguous.
+_Avoid_: sliding window, brush, drag window, range window
 
 **Selection Snapshot**:
 Whether a line was selected at the moment its records were grouped, recorded once per line rather

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,6 +47,24 @@ handling belongs to the chart plugin that draws it rather than to the chart's ow
 callbacks.
 _Avoid_: marker strip, axis dots, annotation row
 
+**Pinned Month**:
+The single sticky Month the chart, the tooltip and the context-log panel all read. Owned by the
+output area rather than by any one of them, because they are three views of one piece of state.
+**At most one exists, and it must be released before another can be taken** — a click while a Month
+is pinned releases it and pins nothing, identically on the chart and in the panel. Distinct from the
+hovered Month, which is transient and which a pin outranks. A pin marks what is read; it never opens
+or scrolls a view in order to be seen. See
+[ADR-0011](docs/adr/0011-a-pin-marks-it-never-moves-a-view.md).
+_Avoid_: selected month, active month, focused month, sticky tooltip
+
+**Range Selection**:
+The drag across the plot that sets the Month Window, and the band drawn while that drag is in
+progress. It begins only once the pointer has travelled far enough for the gesture to be a drag
+rather than a click, so a plain click pins a Month and paints nothing. Deliberately mouse-only: a
+horizontal drag across a chart is how a page is scrolled on a phone.
+_Avoid_: sliding window, brush, drag window, range window — *window* already belongs to the Month
+Window and the Event Window, and a third sense of it makes all three ambiguous
+
 **Selection Snapshot**:
 Whether a line was selected at the moment its records were grouped, recorded once per line rather
 than re-checked per record. It is a property of the Ridership View, not of the line — the same line

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ Then read whichever guide matches what you're about to do. Don't read them all.
 | [`guides/data.md`](guides/data.md) | Ingesting new ridership data | You have new files from a records request |
 | [`../scripts/README.md`](../scripts/README.md) | The Python pipeline in full — records requests, every script, compression | Working on the pipeline itself |
 | [`ROADMAP.md`](ROADMAP.md) | The stop-level ridership batch — five PRs, the contract they share, the named risks | You're picking up one of those PRs, or wondering where stop data is up to |
-| [`adr/`](adr/) | Ten decisions, with the reasoning | You want to know *why*, or you're about to change something one of them covers |
+| [`adr/`](adr/) | Eleven decisions, with the reasoning | You want to know *why*, or you're about to change something one of them covers |
 | [`architecture/diagrams.md`](architecture/diagrams.md) | 21 diagrams — system, data, state, URL, seams, tests, CI | You'd rather see it than read it |
 | [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Conventions, and the one docs rule | Before your first PR |
 | [`../DATA_RELEASE_NOTES.md`](../DATA_RELEASE_NOTES.md) | What data landed when | Tracing a change in the numbers |
@@ -48,6 +48,7 @@ Then read whichever guide matches what you're about to do. Don't read them all.
 | [0008](adr/0008-panel-layout-is-a-tailwind-grid-with-url-synced-settings.md) | Panel layout is a Tailwind grid with URL-synced settings; dockview was reverted | accepted |
 | [0009](adr/0009-the-two-window-rules-are-one-rule.md) | One window rule, inclusive on both ends — the chart's two-month offset is gone | accepted, **supersedes 0001** |
 | [0010](adr/0010-the-event-gutter-hit-tests-itself.md) | The Event Gutter hit-tests itself, because Chart.js will not | accepted |
+| [0011](adr/0011-a-pin-marks-it-never-moves-a-view.md) | A pin marks what is read; it never moves what is shown — release before taking, and no auto-move | accepted, **not yet landed** — #199 and #200 implement it |
 
 ## Not for humans
 

--- a/docs/adr/0011-a-pin-marks-it-never-moves-a-view.md
+++ b/docs/adr/0011-a-pin-marks-it-never-moves-a-view.md
@@ -1,6 +1,9 @@
 # A pin marks what is read; it never moves what is shown
 
-Status: accepted
+Status: accepted, **not yet implemented** —
+[#199](https://github.com/streetsforall/metro_ridership_app/issues/199) lands the release-first rule
+and [#200](https://github.com/streetsforall/metro_ridership_app/issues/200) the removal of the
+auto-move.
 
 A Pinned Month is a mark. It says *this is the Month everything is reporting on*, and that is the
 whole of its job. It does not decide which Month gets marked next, and it does not open, scroll or
@@ -57,11 +60,16 @@ costs the reader nothing they cannot read on the chart.
 
 - The pin toggle states the rule once, where the Pinned Month is owned. The chart and the panel both
   route through it rather than each deciding for itself; a second copy of the rule is how two
-  surfaces start disagreeing about what a click means.
+  surfaces start disagreeing about what a click means. That includes the Event Gutter's own click
+  path — [ADR-0010](0010-the-event-gutter-hit-tests-itself.md) already requires the gutter to land on
+  the *same* pin state the plot drives rather than a parallel copy, and this rule is a property of
+  that state rather than of any route into it.
 - Escape, the press-outside release and the keyboard pin path are unchanged. All three already
   release rather than retarget, which is the rule this generalises.
-- Completing a Range Selection still does not leave a Pinned Month behind. The suppression that
-  stops a promoted drag from also pinning is a separate mechanism and is untouched.
+- Completing a Range Selection still does not leave a Pinned Month behind. Nothing here changes that
+  outcome; the suppression that produces it is a separate mechanism, and it is
+  [#198](https://github.com/streetsforall/metro_ridership_app/issues/198) — not this decision — that
+  narrows it to fire only on a promoted drag.
 - The context-log panel's own collapse toggle, ordering and content are untouched. Only the
   automatic movement goes, and any state that existed solely to drive it goes with it.
 - Specs asserting that pinning opens or scrolls the panel are asserting a behaviour that is being

--- a/docs/adr/0011-a-pin-marks-it-never-moves-a-view.md
+++ b/docs/adr/0011-a-pin-marks-it-never-moves-a-view.md
@@ -1,0 +1,70 @@
+# A pin marks what is read; it never moves what is shown
+
+Status: accepted
+
+A Pinned Month is a mark. It says *this is the Month everything is reporting on*, and that is the
+whole of its job. It does not decide which Month gets marked next, and it does not open, scroll or
+otherwise rearrange any view in order to be seen.
+
+Two rules follow from that one principle, and they are recorded together because splitting them
+would hide that they are the same rule:
+
+- **Release before taking.** If any Month is pinned, a click releases it and pins nothing. A further
+  click pins the Month it landed on. Identically on the chart and in the context-log panel.
+- **No auto-move.** Pinning never opens the context-log panel and never scrolls a row into view.
+  The panel's open state and scroll position belong to the reader.
+
+## What motivated this
+
+The accidental-repin report — [#196](https://github.com/streetsforall/metro_ridership_app/issues/196),
+defects 4 and 5. A reader with a Month pinned clicks elsewhere on the chart meaning to dismiss the
+readout, and pins something else instead. There is no way back to an unpinned chart except finding
+the exact Month they started on, or knowing that Escape works. The same report carries the other
+half: pinning a Month force-opens the context-log panel and scrolls its matching row into view, so a
+reader part-way down the log is moved somewhere else by an action they took on the chart.
+
+Both are the same mistake made twice. The pin was allowed to *do* things — to retarget itself, and
+to move a view — on top of marking a Month.
+
+## Why one decision and not two
+
+A single pin with one release rule is explainable in a sentence: *click to pin, click again to
+release, and one is the most you can have.* Direct-switching on the chart while the panel toggles is
+one piece of state behaving two ways, which is two states wearing one name — and the reader is the
+one who has to keep the two models in their head.
+
+The auto-open and the auto-scroll are that same overreach in the other direction. A pin that moves
+a view is a pin that has an opinion about what the reader should be looking at. Recorded separately,
+the two would read as an interaction tweak and a scroll-behaviour tweak; recorded together, they
+read as what they are — the boundary of what a pin is allowed to do.
+
+That boundary is what a later change has to argue against. Restoring direct-switching as a "fix" for
+the extra click, or restoring the auto-scroll as a "fix" for the off-screen row, each looks
+reasonable on its own and each puts back half of the thing being removed here.
+
+## What this costs, and why it is accepted
+
+**Moving between Months takes two clicks rather than one.** That is the point: one accidental step
+becomes two deliberate ones. The reader who wanted to move the pin loses a click; the reader who
+wanted to dismiss it stops being surprised.
+
+**Pin a Month from the chart while the panel is collapsed and the highlighted row is off-screen,
+with no cue that it exists.** Deliberate. The tooltip carries the event content in full, so the
+context-log panel is a second view of the events rather than the only one — the panel staying shut
+costs the reader nothing they cannot read on the chart.
+
+## Consequences
+
+- The pin toggle states the rule once, where the Pinned Month is owned. The chart and the panel both
+  route through it rather than each deciding for itself; a second copy of the rule is how two
+  surfaces start disagreeing about what a click means.
+- Escape, the press-outside release and the keyboard pin path are unchanged. All three already
+  release rather than retarget, which is the rule this generalises.
+- Completing a Range Selection still does not leave a Pinned Month behind. The suppression that
+  stops a promoted drag from also pinning is a separate mechanism and is untouched.
+- The context-log panel's own collapse toggle, ordering and content are untouched. Only the
+  automatic movement goes, and any state that existed solely to drive it goes with it.
+- Specs asserting that pinning opens or scrolls the panel are asserting a behaviour that is being
+  removed. They are deleted rather than adjusted, and replaced by ones asserting the panel holds
+  still.
+- `CONTEXT.md` gains **Pinned Month**, which states the release-first rule as part of the term.

--- a/docs/architecture/diagrams.md
+++ b/docs/architecture/diagrams.md
@@ -1252,7 +1252,7 @@ flowchart TB
   subgraph authority["Authority order — who wins on conflict"]
     direction TB
     ctx["CONTEXT.md — where a term conflicts<br/>with a name in the source, the term wins"]
-    adrs["docs/adr/ — ten decisions"]
+    adrs["docs/adr/ — eleven decisions"]
     prose["docs/how-it-works.md · docs/guides/"]
     pointer["CLAUDE.md — pointer file, no facts of its own"]
     ctx --> adrs --> prose --> pointer

--- a/docs/architecture/mermaid/21-docs-adr-map.mmd
+++ b/docs/architecture/mermaid/21-docs-adr-map.mmd
@@ -15,7 +15,7 @@ flowchart TB
   subgraph authority["Authority order — who wins on conflict"]
     direction TB
     ctx["CONTEXT.md — where a term conflicts<br/>with a name in the source, the term wins"]
-    adrs["docs/adr/ — ten decisions"]
+    adrs["docs/adr/ — eleven decisions"]
     prose["docs/how-it-works.md · docs/guides/"]
     pointer["CLAUDE.md — pointer file, no facts of its own"]
     ctx --> adrs --> prose --> pointer


### PR DESCRIPTION
Closes #197. Parent: #196.

Docs-only. Zero files under `src/`. This lands first so every other ticket in the #196 batch writes in the settled vocabulary.

## What's here

**[CONTEXT.md](../blob/claude/issue-197-glossary/CONTEXT.md)** gains two terms, placed after **Event Gutter** in *The derived view* — the other screen-surface terms live there, and *The inputs* is data shapes.

- **Pinned Month** — one sticky Month, owned by the output area because the chart, the tooltip and the panel are three views of one piece of state. At most one exists, and it must be released before another can be taken.
- **Range Selection** — the drag that sets the Month Window, and the band drawn while it is in progress. `_Avoid_` names **sliding window** and **brush** (plus *drag window*, *range window*); the reason — *window* already belongs to Month Window and Event Window — sits in the entry body, where every other entry keeps its reasoning.

**[ADR-0011](../blob/claude/issue-197-glossary/docs/adr/0011-a-pin-marks-it-never-moves-a-view.md)** — *a pin marks what is read; it never moves what is shown.* One principle, two consequences: release-before-taking, and no auto-open or auto-scroll. Motivation named: the accidental-repin report, #196 defects 4 and 5.

They are one record because splitting them would hide that they are the same overreach twice. Restoring direct-switching as a "fix" for the extra click, and restoring the auto-scroll as a "fix" for the off-screen row, each looks reasonable alone and each puts back half of what is being removed. #199 and #200 implement it; the ADR's status line says so.

**[docs/README.md](../blob/claude/issue-197-glossary/docs/README.md)** gains the index row and the repo-map count. Diagram 21's count followed, regenerated with `npm run docs:architecture` — one line of diff.

## Review

A `/code-review` pass ran on the branch. Applied:

- ADR `:63` claimed the post-drag click suppression is **"untouched"**. Wrong — #196 explicitly narrows it to fire only on a promoted drag. Now: the *outcome* is unchanged, #198 owns the mechanism.
- Status line carries the not-yet-implemented fact, so the index row restates the record rather than adding to it.
- Cross-link to ADR-0010, which owns a second route to a pin (`onGutterClick`) and already requires it to land on the same state — so this rule reaches it.
- `_Avoid_` back to a bare list.

## Judgement calls — flagged, not acted on

- **"The diagram asserts eleven decisions and draws ten."** The premise is wrong: `21-docs-adr-map.mmd` has no `a8` either. It enumerated 9 of 10 before this change and 9 of 11 after — the node groups were never a complete list. Count bumped, groups left alone. Adding a fourth *accepted, not yet implemented* group for one ADR is a call for the repo owner, not a drive-by.
- **CONTEXT.md states unlanded behaviour in present tense.** That is the file's own stated premise — the term wins, the source is what's out of date. #197 exists to settle the vocabulary before the code.
- **Range Selection's travel-threshold and mouse-only sentences read as scope creep.** Both are settled decisions in #196. An entry that omits why the band does not paint on a click is an entry #198 would have to rewrite.
- **The ADR's consequences read as an implementation plan.** They are the terms the decision is accepted on. 0005 and 0009 both close the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
