### PR TITLE
fix(chart): a repaint is not a gesture

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -131,6 +131,15 @@ These are the things that look like bugs and aren't.
   dep array is what stops the sparkline effect thrashing. `monthAxis` sits in the same array
   unstringified because `LineSelector` memoises it. Don't "fix" these.
 
+- **Chart plugins ignore replayed events, and the Range Selection plugin must.** `Chart#update`
+  finishes by replaying `_lastEvent` through the whole event pipeline, and `determineLastEvent`
+  keeps the *previous* event across a click — so after a press and release, `_lastEvent` is still
+  the `mousedown`. Every repaint therefore delivers a second `mousedown` to `afterEvent` with the
+  button already up. `rangeSelect` returns on `args.replay` for that reason: without it, pinning a
+  Month re-armed the press and the next mouse move painted a band the reader was not dragging.
+  Anything new that reads pointer state in `afterEvent` needs the same guard —
+  [`src/chart/rangeSelect.ts`](../src/chart/rangeSelect.ts).
+
 - **Line colours.** Official rail and BRT lines have hardcoded brand colours in `definedLines`
   ([`src/utils/lines.ts`](../src/utils/lines.ts)); every other bus line gets a deterministic
   golden-angle HSL hue, so the chart and the map always agree.

--- a/src/chart/__tests__/rangeSelect.test.ts
+++ b/src/chart/__tests__/rangeSelect.test.ts
@@ -12,6 +12,7 @@ type EventArgs = {
   event: { type: string; x: number };
   inChartArea: boolean;
   changed?: boolean;
+  replay?: boolean;
 };
 type AfterEvent = (chart: unknown, args: EventArgs, opts: unknown) => void;
 type AfterDraw = (chart: unknown, args: unknown, opts: unknown) => void;
@@ -66,6 +67,17 @@ const move = (chart: unknown, x: number) =>
   afterEvent(chart, { event: { type: 'mousemove', x }, inChartArea: true }, {});
 const release = (chart: unknown, x: number) =>
   afterEvent(chart, { event: { type: 'mouseup', x }, inChartArea: true }, {});
+/**
+ * The same event Chart.js hands back after a repaint. `Chart#update` replays
+ * `_lastEvent` through the event pipeline, and across a click that is still the
+ * original `mousedown` — so this is a press arriving with the button already up.
+ */
+const replay = (chart: unknown, type: string, x: number) =>
+  afterEvent(
+    chart,
+    { event: { type, x }, inChartArea: true, replay: true },
+    {},
+  );
 
 /** Waits out the hold, which is one of the two ways a press promotes. */
 const hold = () => vi.advanceTimersByTime(PROMOTE_HOLD_MS);
@@ -143,6 +155,39 @@ describe('drag to select a range', () => {
   it('clamps a drag past the right edge to the last month', () => {
     const { onSelect } = drag(100, 5000);
     expect(onSelect).toHaveBeenCalledWith(2, 11);
+  });
+
+  /**
+   * A repaint is not a gesture. Every branch is skipped, not just the press —
+   * a replayed `mouseup` would otherwise complete a Range Selection nobody
+   * released, and a replayed `mousemove` would extend a live band on a frame.
+   */
+  it('starts no press from a replayed mousedown', () => {
+    const chart = makeChart();
+    replay(chart, 'mousedown', 100);
+    expect(pressedOf(chart)).toBeFalsy();
+  });
+
+  it('leaves no hold timer behind after a replayed mousedown', () => {
+    const chart = makeChart();
+    replay(chart, 'mousedown', 100);
+    hold();
+    expect(draggingOf(chart)).toBeFalsy();
+    expect(chart.render).not.toHaveBeenCalled();
+  });
+
+  it('does not complete a selection from a replayed mouseup', () => {
+    const onSelect = vi.fn();
+    const chart = makeChart(onSelect);
+    press(chart, 100);
+    hold();
+    move(chart, 300);
+    afterEvent(
+      chart,
+      { event: { type: 'mouseup', x: 300 }, inChartArea: true, replay: true },
+      {},
+    );
+    expect(onSelect).not.toHaveBeenCalled();
   });
 
   it('does nothing on a mouseup that no mousedown started', () => {
@@ -359,6 +404,23 @@ describe('the drag band', () => {
     const chart = makeChart();
     press(chart, 100);
     move(chart, 110);
+    afterDraw(chart, {}, {});
+    expect(chart.ctx.fillRect).not.toHaveBeenCalled();
+    expect(chart.ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The bug this guards. Pinning a month re-renders the chart, `Chart#update`
+   * replays the gesture's own `mousedown`, and the press came back to life with
+   * the button up — so a band followed the cursor after an ordinary click.
+   */
+  it('paints nothing after a click whose repaint replays the mousedown', () => {
+    const chart = makeChart();
+    press(chart, 100);
+    release(chart, 100);
+    replay(chart, 'mousedown', 100); // the pin's re-render
+    hold();
+    move(chart, 300);
     afterDraw(chart, {}, {});
     expect(chart.ctx.fillRect).not.toHaveBeenCalled();
     expect(chart.ctx.stroke).not.toHaveBeenCalled();

--- a/src/chart/rangeSelect.ts
+++ b/src/chart/rangeSelect.ts
@@ -105,6 +105,20 @@ export const rangeSelectPlugin: Plugin<'line'> = {
   id: 'rangeSelect',
 
   afterEvent(chart, args) {
+    /**
+     * A gesture is driven by the pointer, never by a repaint.
+     *
+     * `Chart#update` ends by replaying `_lastEvent` through the whole event
+     * pipeline — and `determineLastEvent` deliberately keeps the *previous*
+     * event across a click, so after a press-and-release `_lastEvent` is still
+     * the `mousedown`. Anything that re-renders the chart therefore delivers a
+     * second `mousedown` here with the button already up: the press is re-armed,
+     * the hold timer restarts, and the next mousemove promotes a drag the reader
+     * is not making. Pinning a month is exactly such a re-render, so clicking a
+     * month left a band trailing the cursor.
+     */
+    if (args.replay) return;
+
     const c = chart as ChartWithDrag;
     const state = (c.$rangeSelect ??= {
       startX: 0,


### PR DESCRIPTION
Reported from the running app: **click a Month and a Range Selection band follows the cursor with the mouse button up.**

Not a regression from #210 — it reproduces identically at `ae0f497`, the commit before it. It arrived with the press/drag split in #198.

## Cause

`Chart#update` ends by replaying `_lastEvent` through the whole event pipeline:

```js
const { _active, _lastEvent } = this;
if (_lastEvent) this._eventHandler(_lastEvent, true);
```

and `determineLastEvent` deliberately keeps the *previous* event across a click — `isClick` returns `lastEvent`, not `e`. So after a press and release, `_lastEvent` is still the **`mousedown`**.

Every repaint therefore delivers a second `mousedown` to `rangeSelectPlugin.afterEvent`, with the button already up. `pressed` comes back to life, the hold timer restarts, and the next mouse move promotes a drag the reader is not making. Pinning a Month is exactly such a repaint, which is why a single click was enough.

Measured in the browser, before the fix — after `mouse.click()` and a 200px move:

```
PROBE click  {"pressed":true, "dragging":false, "holdTimer":4}    ← re-armed by the replay
PROBE moved  {"pressed":true, "dragging":true,  "holdTimer":null} ← band painting, button up
```

## Fix

One guard at the top of `afterEvent`:

```ts
if (args.replay) return;
```

A gesture is driven by the pointer, never by a frame. At the top rather than per-branch, because every branch is wrong on a replay: a replayed `mouseup` would complete a Range Selection nobody released, and a replayed `mousemove` would extend a live band on a repaint.

After the fix, same probe:

```
PROBE click  {"pressed":false,"dragging":false,"holdTimer":null}
PROBE moved  {"pressed":false,"dragging":false,"holdTimer":null}
PROBE pinned true
```

## Tests

Four specs at the plugin seam — the only seam that can observe the band, since it is painted to a canvas rather than rendered as DOM. **All four fail without the guard** (verified by reverting it):

- a replayed `mousedown` starts no press
- and leaves no hold timer behind
- a replayed `mouseup` completes no selection
- **the reported bug**: press, release, replayed `mousedown`, wait out the hold, move — nothing paints

The existing 29 gesture specs are untouched and still pass; a real drag is delivered as real events and is unaffected.

`npm run lint` · 868 unit tests · `npm run build` — green. Playwright: **81 passed**, no baseline moved.

## Docs

One entry in `docs/how-it-works.md` under *Conventions and quirks*, since a bare `if (args.replay) return;` reads as dead code. It also generalises the rule: anything new reading pointer state in `afterEvent` needs the same guard.
