### PR TITLE
fix(chart): releasing a pin releases the Month Readout with it (#204)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,8 +72,12 @@ and no clamp, capped at a third of the plot's height and scrolling within that. 
 chart rather than on any part of it, escaping the pane's padding and border to do so — the readout
 and the Month it describes stop competing for the same pixels, which is the whole of the mode. The
 cap is the reader's to lift: a pinned strip with anything under it offers **Expand**, which removes
-the ceiling rather than raising it, so nothing is left clipped. Distinct from a Line Readout, which is figures for one Line
-over the whole Month Window.
+the ceiling rather than raising it, so nothing is left clipped. Unpinned it cannot offer a control —
+it does not accept the pointer — so it says *Click to pin* instead; a capped readout never withholds
+content silently. **Releasing a Pinned Month dismisses the readout** rather than demoting it to a
+hovering one — on a touch screen there is no hover to fall back on and the demoted readout could
+neither be dismissed nor read. Distinct from a Line Readout, which is figures for one Line over the
+whole Month Window.
 _Caution_: "strip" is the Event Gutter's word too, and the two are different things at opposite ends
 of the plot. Say **top strip** or **Month Readout strip** where both are in play.
 _Avoid_: tooltip content, hover card, mobile tooltip
@@ -98,8 +102,9 @@ The single sticky Month the chart, the tooltip and the context-log panel all rea
 output area rather than by any one of them, because they are three views of one piece of state.
 **At most one exists, and it must be released before another can be taken** — a click while a Month
 is pinned releases it and pins nothing, identically on the chart and in the panel. Distinct from the
-hovered Month, which is transient and which a pin outranks. A pin marks what is read; it never opens
-or scrolls a view in order to be seen. See
+hovered Month, which is transient and which a pin outranks — and which a release clears, so the
+Month Readout goes when the pin does rather than falling back to a hover a touch screen could never
+end. A pin marks what is read; it never opens or scrolls a view in order to be seen. See
 [ADR-0011](docs/adr/0011-a-pin-marks-it-never-moves-a-view.md).
 _Avoid_: selected month, active month, focused month, sticky tooltip
 

--- a/docs/adr/0011-a-pin-marks-it-never-moves-a-view.md
+++ b/docs/adr/0011-a-pin-marks-it-never-moves-a-view.md
@@ -99,3 +99,45 @@ released over; only the later `click` pass, the one that got suppressed, was eve
 One deliberate behaviour change comes with it: a right-click inside the plot used to toggle the pin,
 via `contextmenu`. It no longer does anything. Nothing asked for that behaviour and no spec covered
 it.
+
+### What release-first exposed: a release that released nothing
+
+Found from a phone, after the Month Readout gained its top strip in #204. Recorded here rather than
+as its own decision, because it is this rule finishing rather than an exception to it.
+
+Release-first assumed that what sits *underneath* a released pin is transient. On a mouse it is: the
+hovered Month is disposed of by the next movement and ended for good by `mouseout`. A touch screen
+sends no `mouseout`, and a finger has no resting position — so the hover a tap synthesises is not
+"the Month under the pointer" but "the last Month tapped", permanently.
+
+Releasing a pin therefore did not release anything the reader could see. The readout stayed up in
+its *unpinned* form, which on a narrow chart is a strip still capped at a third of the plot but with
+no Expand control, no full description and no source link: a box naming a Month whose event it was
+too short to show, and offering nothing to open. Meanwhile the context-log panel banded no row,
+because nothing was pinned — the two views disagreed, which is the thing the shared pin exists to
+prevent.
+
+**So releasing a pin releases the Month Readout with it, on every pointer.** The claim above that
+*"the tooltip carries the event content in full, so the context-log panel is a second view"* is what
+this restores: unpinned on a phone, it carried none of it.
+
+Every pointer, rather than only the ones that cannot hover, and that is a decision rather than
+laziness. Asking the platform — `matchMedia('(hover: none)')`, and dropping the hover only there —
+reads better and does not work: the same emulated phone answers that query differently between one
+render and the next, so the fix would hold or not hold at random, and the test proving it would be
+flaky in both directions. A rule that has to be true cannot rest on an answer that wobbles.
+
+What it costs on a mouse: releasing a pin without moving the pointer takes the readout away rather
+than leaving a hovering one behind, until the pointer moves. Small, and arguably what "release"
+should have looked like all along — the reader clicking to dismiss gets a dismissal.
+
+The plausible-looking alternative, recorded so it is argued with rather than rediscovered: decouple
+**Expand** from the pin, and let the orphaned readout open itself. The strip sits wholly above the
+plot and so, unlike the floating box, could safely take the pointer. It is still wrong. Unpinned
+means clamped descriptions and no source links — that is what pinning *is* — so an expanded unpinned
+strip would show its full height with its content still abridged, and "Expand" would mean "all of
+the shortened version". That is precisely the confusion `STRIP_HEIGHT_SHARE` rejected a second cap
+for. It would also leave a release that visibly releases nothing.
+
+The two-click cost above is unchanged by this. It was already the price of the rule; the first of
+the two clicks now clears the screen rather than half-clearing it.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -131,14 +131,26 @@ These are the things that look like bugs and aren't.
   dep array is what stops the sparkline effect thrashing. `monthAxis` sits in the same array
   unstringified because `LineSelector` memoises it. Don't "fix" these.
 
-- **Chart plugins ignore replayed events, and the Range Selection plugin must.** `Chart#update`
-  finishes by replaying `_lastEvent` through the whole event pipeline, and `determineLastEvent`
-  keeps the *previous* event across a click — so after a press and release, `_lastEvent` is still
-  the `mousedown`. Every repaint therefore delivers a second `mousedown` to `afterEvent` with the
-  button already up. `rangeSelect` returns on `args.replay` for that reason: without it, pinning a
-  Month re-armed the press and the next mouse move painted a band the reader was not dragging.
-  Anything new that reads pointer state in `afterEvent` needs the same guard —
-  [`src/chart/rangeSelect.ts`](../src/chart/rangeSelect.ts).
+- **Everything that reads pointer state ignores replayed events.** `Chart#update` finishes by
+  replaying `_lastEvent` through the whole event pipeline, and `determineLastEvent` keeps the
+  *previous* event across a click — so after a press and release, `_lastEvent` is still the
+  `mousedown`. It also keeps the previous event whenever the pointer is outside `chartArea`, which
+  the Event Gutter always is. Every repaint therefore re-delivers a stale gesture, and pinning a
+  Month is a repaint.
+
+  Three paths read pointer state and all three return on the replay flag:
+
+  - [`src/chart/rangeSelect.ts`](../src/chart/rangeSelect.ts) — `args.replay` in `afterEvent`.
+    Without it a repaint re-armed the press and the next mouse move painted a band nobody dragged.
+  - [`src/chart/eventGutter.ts`](../src/chart/eventGutter.ts) — the same, added later. Without it a
+    replayed `click` re-answered the pin under the release-first rule (ADR-0011), and a replayed
+    `mousemove` put the hover back on the Month the reader had just left.
+  - the tooltip's `external` in [`src/components/RidershipChart.tsx`](../src/components/RidershipChart.tsx)
+    — not a plugin hook and so easily missed. **Chart.js passes `replay` here too, at runtime, but
+    its published types declare only `{ chart, tooltip }`**, so the flag has to be read through a
+    local widening (`TooltipExternalArgs`). That omission is why this one went unguarded longest.
+
+  Anything new that reads pointer state needs the same guard.
 
 - **Line colours.** Official rail and BRT lines have hardcoded brand colours in `definedLines`
   ([`src/utils/lines.ts`](../src/utils/lines.ts)); every other bus line gets a deterministic

--- a/e2e/chart-interaction.spec.ts
+++ b/e2e/chart-interaction.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { gotoDashboard, desktopOnly } from './helpers';
+import { gotoDashboard, desktopOnly, mobileOnly } from './helpers';
 
 /**
  * DOM coverage for the chart's interactive layer: the pinned readout, the
@@ -311,12 +311,12 @@ test.describe('the Event Gutter', () => {
    * triangle the canvas sees a mouseout and the hover clears with the pin. The
    * log row is the unambiguous witness — it is DOM, and it tracks the pin alone.
    *
-   * Desktop only, and this one is a real limitation rather than a test artifact.
-   * The pinned readout is a fixed 256px box; on a 390px screen it covers the
-   * triangle that opened it, so a second tap on the same target lands on the
-   * readout and never reaches the canvas. Re-tapping is not how a phone reader
-   * gets out of it — pressing anywhere outside dismisses, which `OutputArea`
-   * owns and covers for every pin source, not just this one.
+   * Desktop only because that is the layout this asserts — the floating box.
+   * It was desktop only for a harder reason until #214: the readout was a fixed
+   * 256px box at every width, so on a 390px screen it covered the triangle that
+   * opened it and a second tap landed on the readout instead of the canvas. The
+   * strip sits wholly above the plot, so that is no longer true, and the touch
+   * case is covered on its own terms in `exiting on a touch screen` below.
    */
   test.describe('re-pointing', () => {
     desktopOnly();
@@ -335,6 +335,58 @@ test.describe('the Event Gutter', () => {
       await expect(
         page.locator('[data-testid="chart-tooltip"][data-pinned="true"]'),
       ).toHaveCount(0);
+    });
+  });
+
+  /**
+   * Touch only, and the mirror of `re-pointing` above: what "exit" means where
+   * there is no hover to fall back to.
+   *
+   * A finger has no resting position, so the hover a tap synthesises is never
+   * taken back — no `mouseout` follows it. Releasing the pin therefore used to
+   * leave the readout on screen in its *unpinned* form, which at this width is a
+   * strip still capped at a third of the plot but with no Expand control, no full
+   * description and no source link: a box naming a month it could not show. The
+   * pin is the only thing holding a readout up here, so releasing it dismisses.
+   *
+   * Asserted through the Event Gutter because that is where a phone reader taps
+   * for a month that has events, and it is the path whose replayed pointer state
+   * is stalest — see the guard in `eventGutter.ts`.
+   */
+  test.describe('exiting on a touch screen', () => {
+    mobileOnly();
+
+    test('tapping another month dismisses the readout, not only its pin', async ({
+      page,
+    }) => {
+      await gotoDashboard(page, WINDOW);
+
+      await tapGutter(page, '2020 3');
+      await expect(tooltip(page)).toHaveAttribute('data-layout', 'strip');
+      await expect(tooltip(page)).toHaveAttribute('data-pinned', 'true');
+
+      // The control exists because the strip is capped and this month carries an
+      // event — the state the whole readout-on-a-phone problem lives in.
+      const expand = tooltip(page).getByRole('button', { name: 'Expand' });
+      await expect(expand).toBeVisible();
+      await expand.tap();
+      await expect(tooltip(page)).toHaveAttribute('data-expanded', 'true');
+
+      // A *different* month, which is both what the reader does and the only
+      // version of this gesture that can fail. Tapping the same triangle twice
+      // lands on the coordinates the pointer is already at, so the browser
+      // synthesises no `mousemove` and there is no phantom hover to be left
+      // behind — it passes with or without the fix, and asserts nothing.
+      await tapGutter(page, '2020 6');
+
+      await expect(tooltip(page)).toHaveCount(0);
+      // The ghost named as well as counted. Both fail together today; they come
+      // apart the moment a hover is let back into the chain, and it is the
+      // unpinned readout specifically that is the bug.
+      await expect(
+        page.locator('[data-testid="chart-tooltip"][data-pinned="false"]'),
+      ).toHaveCount(0);
+      await expect(firstLogRow(page)).toHaveAttribute('aria-pressed', 'false');
     });
   });
 

--- a/src/@types/chart.types.ts
+++ b/src/@types/chart.types.ts
@@ -7,6 +7,21 @@ export interface CustomChartData {
   stat: number | null;
 }
 
+/**
+ * What Chart.js actually hands the tooltip's `external` callback.
+ *
+ * It passes a third field, `replay`, marking the call as coming from
+ * `Chart#update`'s replay of `_lastEvent` rather than from the pointer —
+ * `Tooltip#update` forwards it verbatim. Its published type declares only
+ * `{ chart, tooltip }`, and the omission cannot be repaired by module
+ * augmentation because `external` is a method signature rather than a named
+ * argument type. So the argument is widened at the call site through this,
+ * which at least names what is being asserted and why.
+ */
+export interface TooltipExternalArgs {
+  replay?: boolean;
+}
+
 declare module 'chart.js' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface PluginOptionsByType<TType extends ChartType> {

--- a/src/chart/__tests__/eventGutter.test.ts
+++ b/src/chart/__tests__/eventGutter.test.ts
@@ -10,6 +10,7 @@ type AfterDraw = (chart: unknown, args: unknown, opts: unknown) => void;
 type GutterEventArgs = {
   event: { type: string; x?: number | null; y?: number | null };
   inChartArea: boolean;
+  replay?: boolean;
 };
 type AfterEvent = (chart: unknown, args: GutterEventArgs, opts: unknown) => void;
 const plugin = eventGutterPlugin as unknown as {
@@ -402,6 +403,33 @@ describe('event gutter hit-testing', () => {
     const chart = makeChart([eventAt(3)], { onGutterClick });
     afterEvent(chart, below('click', 175), {});
     expect(onGutterClick).toHaveBeenCalledWith(5);
+  });
+
+  /**
+   * A repaint is not a gesture — `rangeSelect` keeps the same rule, and the
+   * gutter needs it more. `Chart#update` replays `_lastEvent`, and
+   * `determineLastEvent` keeps the previous event both across a click and
+   * whenever the pointer is outside `chartArea` — which the gutter always is.
+   * So pinning a month re-delivers the click that pinned it, and under
+   * release-first (ADR-0011) the replay releases what the gesture just took.
+   */
+  const replayed = (type: string, x: number) => ({
+    ...below(type, x),
+    replay: true,
+  });
+
+  it('ignores a click replayed by a repaint', () => {
+    const onGutterClick = vi.fn();
+    const chart = makeChart([eventAt(3)], { onGutterClick });
+    afterEvent(chart, replayed('click', 100), {});
+    expect(onGutterClick).not.toHaveBeenCalled();
+  });
+
+  it('ignores a hover replayed by a repaint', () => {
+    const onGutterHover = vi.fn();
+    const chart = makeChart([eventAt(3)], { onGutterHover });
+    afterEvent(chart, replayed('mousemove', 100), {});
+    expect(onGutterHover).not.toHaveBeenCalled();
   });
 });
 

--- a/src/chart/eventGutter.ts
+++ b/src/chart/eventGutter.ts
@@ -128,6 +128,20 @@ export const eventGutterPlugin: Plugin<'line'> = {
    * See ADR-0010. Anything later drawn below the plot needs the same treatment.
    */
   afterEvent(chart, args) {
+    /**
+     * A repaint is not a gesture — the same rule `rangeSelect` keeps, for the
+     * same reason and with more force here.
+     *
+     * `Chart#update` replays `_lastEvent` through the event pipeline, and
+     * `determineLastEvent` keeps the *previous* event both across a click and
+     * whenever the pointer is outside `chartArea`. The gutter is outside
+     * `chartArea` by definition, so its `_lastEvent` is the stalest of any path:
+     * a pin re-renders the chart, the replay arrives here as a fresh `click` or
+     * `mousemove` at the old position, and the month the reader just left is
+     * pinned or hovered back over the one they chose.
+     */
+    if (args.replay) return;
+
     const { onGutterClick, onGutterHover } = readOptions(chart);
     const { type, x, y } = args.event;
 

--- a/src/components/ChartTooltip.tsx
+++ b/src/components/ChartTooltip.tsx
@@ -1,5 +1,4 @@
 import {
-  useEffect,
   useLayoutEffect,
   useState,
   type CSSProperties,
@@ -184,23 +183,40 @@ export default function ChartTooltip({
    *
    * Both live above the early return, because hooks cannot be called
    * conditionally and the readout renders nothing for a month it has not got.
+   *
+   * A new Month is a new readout: it opens collapsed, and at the first of its
+   * events rather than wherever the last Month was left — which would otherwise
+   * open a two-event Month at "2 of 2" because the Month before it had three.
+   *
+   * Both state the Month they belong to rather than being reset by an effect.
+   * The reset was a *passive* effect, so the first committed frame of a new
+   * Month still carried the previous Month's expansion — uncapped — and the
+   * measurement below, which decides whether to offer the control that lifts the
+   * cap, ran against that box and answered for the Month that had gone. Held
+   * against the Month, the collapse and the Month arrive in the same render and
+   * there is no such frame, and nothing needs resetting.
    */
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [expandedFor, setExpandedFor] = useState<number | null>(null);
+  const isExpanded = expandedFor === index;
   const [box, setBox] = useState<HTMLDivElement | null>(null);
   const [hasMore, setHasMore] = useState(false);
-  /** Which of the Month's events is on show. @see step */
-  const [eventIndex, setEventIndex] = useState(0);
+  /** Which of the Month's events is on show, and whose. @see step */
+  const [shownFor, setShownFor] = useState<{
+    month: number | null;
+    position: number;
+  }>({ month: null, position: 0 });
+  const eventIndex = shownFor.month === index ? shownFor.position : 0;
 
   /**
-   * A new Month is a new readout: it opens collapsed, as this one did, and at
-   * the first of its events rather than at whatever position the last Month
-   * happened to be left on — which would otherwise open a two-event Month at
-   * "2 of 2" because the Month before it had three.
+   * A new Month also opens at its heading. React reuses this element across
+   * Months, and the browser keeps a scrolling box's `scrollTop` when its content
+   * is replaced — so a reader who scrolled through one Month's events met the
+   * next one already part-way down, under a heading that had not moved. The same
+   * thing `step` does between two events of one Month, done between Months.
    */
-  useEffect(() => {
-    setIsExpanded(false);
-    setEventIndex(0);
-  }, [index]);
+  useLayoutEffect(() => {
+    if (box) box.scrollTop = 0;
+  }, [box, index]);
 
   /**
    * "More to read" is not a property of the content — a single long description
@@ -241,8 +257,8 @@ export default function ChartTooltip({
    *
    * Clamped at render rather than trusted, because `events` can shrink under a
    * held position without the Month changing — filtering a line away takes its
-   * events with it — and the reset effect above only fires on a new Month. A
-   * clamp here cannot be raced by a re-render the way a second effect could.
+   * events with it — and the position above only starts over on a new Month. A
+   * clamp here cannot be raced by a re-render the way an effect could.
    */
   const shownIndex = Math.min(eventIndex, Math.max(0, events.length - 1));
   const shownEvent = events[shownIndex];
@@ -254,9 +270,10 @@ export default function ChartTooltip({
    * rather than a convenience. Only the strip can be scrolled at all.
    */
   const step = (delta: number) => {
-    setEventIndex((position) =>
-      Math.min(Math.max(position + delta, 0), events.length - 1),
-    );
+    setShownFor({
+      month: index,
+      position: Math.min(Math.max(shownIndex + delta, 0), events.length - 1),
+    });
     if (box) box.scrollTop = 0;
   };
 
@@ -322,16 +339,29 @@ export default function ChartTooltip({
       style={position}
     >
       {/* The month, and — only where the box is capped and there is something
-          under the cap — the control that lifts it. Offered only once pinned:
-          a hovering readout does not accept the pointer, so a button on one is
-          a control the reader can see and cannot press. On touch there is no
-          hover and a tap pins, so the strip is always in the form that has it. */}
+          under the cap — the way to the rest of it. Pinned, that is the control
+          that lifts the cap. Hovering, it is only a sentence: an unpinned
+          readout does not accept the pointer, so a button on one is a control
+          the reader can see and cannot press.
+
+          Hovering *and* capped needs a mouse on a chart under 480px — a narrow
+          panel on a desktop — since a release now takes the readout with it and
+          a tap pins. Rare, and still the state this whole fix is about: a box
+          holding content back with nothing saying so. The same words as the hint
+          at the foot of the box, said where a capped box can still show them. */}
       <div className="flex items-start justify-between gap-2">
         <p className="font-semibold">{formatMonthLabel(months[index])}</p>
+        {!isPinned && hasMore && (
+          <span className="shrink-0 text-stone-400">Click to pin</span>
+        )}
         {isPinned && (hasMore || isExpanded) && (
           <ReadoutButton
             expanded={isExpanded}
-            onPress={() => setIsExpanded((wasExpanded) => !wasExpanded)}
+            onPress={() =>
+              setExpandedFor((wasExpandedFor) =>
+                wasExpandedFor === index ? null : index,
+              )
+            }
           >
             {isExpanded ? 'Collapse' : 'Expand'}
           </ReadoutButton>

--- a/src/components/RidershipChart.tsx
+++ b/src/components/RidershipChart.tsx
@@ -8,7 +8,7 @@ import {
 import { Line as LineChart } from 'react-chartjs-2';
 import colors from 'tailwindcss/colors';
 import ChartTooltip from './ChartTooltip';
-import type { CustomChartData } from '../@types/chart.types';
+import type { CustomChartData, TooltipExternalArgs } from '../@types/chart.types';
 import type { TransitEvent } from '../@types/events.types';
 import {
   consumeDragSuppression,
@@ -120,6 +120,43 @@ export default function RidershipChart({
 
   const pinnedIndex = indexOfMonth(months, pinnedMonth);
   const highlightedIndex = indexOfMonth(months, highlightedMonth);
+
+  /**
+   * Releasing a pin releases the readout with it.
+   *
+   * A hover is meant to be transient, and on a mouse it is: the next movement
+   * retargets it and `mouseout` ends it. A touch screen sends neither. A tap
+   * synthesises one `mousemove` and nothing ever takes it back, so `hoverIndex`
+   * on a phone is not "the month under the pointer" but "the last month
+   * touched", permanently — and it outlived the pin it arrived with. Tapping
+   * another month to get out of a readout releases the pin (ADR-0011) and left
+   * the readout standing in its *unpinned* form, which drops the Expand control,
+   * re-clamps the description and hides the source link while the strip stays
+   * capped at a third of the plot: a box naming a month whose event it was now
+   * too short to show, offering nothing that would open it.
+   *
+   * So the fallback is cleared rather than filtered. Asking the platform
+   * instead — `matchMedia('(hover: none)')`, and only dropping the hover there —
+   * looks tidier and is not dependable: the same emulated phone answers that
+   * query differently between one render and the next, which would make this
+   * fix hold or not hold at random. Clearing needs no such answer, and states
+   * one rule for every pointer.
+   *
+   * Adjusted during render rather than in an effect, which is React's own
+   * pattern for a state that has to follow a prop: the release and the cleared
+   * hover reach the reader in the same paint, with no frame of the readout
+   * still standing between them.
+   *
+   * The cost, on a mouse: releasing a pin without moving takes the readout away
+   * rather than leaving a hovering one, until the pointer moves a pixel. That is
+   * the price of one rule instead of two, and it is what "release" looked like
+   * on a phone all along.
+   */
+  const [lastPinnedMonth, setLastPinnedMonth] = useState(pinnedMonth);
+  if (pinnedMonth !== lastPinnedMonth) {
+    setLastPinnedMonth(pinnedMonth);
+    if (pinnedMonth === null) setHoverIndex(null);
+  }
 
   /**
    * One month drives the tooltip, the crosshair and the enlarged dot, whichever
@@ -246,7 +283,18 @@ export default function RidershipChart({
         // The readout is HTML (see ChartTooltip). Chart.js still tracks the
         // active element — the crosshair reads it — it just paints nothing.
         enabled: false,
-        external: ({ tooltip }) => {
+        external: (args) => {
+          /**
+           * A repaint is not a gesture — `rangeSelect` and the Event Gutter keep
+           * the same rule. `Chart#update` replays `_lastEvent`, and
+           * `determineLastEvent` holds the *previous* event across a click, so
+           * the re-render a pin causes hands this callback the month the reader
+           * just left and sets the hover back to it. Chart.js passes the flag
+           * that says so; only its types leave it out (see `TooltipExternalArgs`).
+           */
+          if ((args as TooltipExternalArgs).replay) return;
+
+          const { tooltip } = args;
           setHoverIndex(
             tooltip.opacity === 0 ? null : (tooltip.dataPoints?.[0]?.dataIndex ?? null),
           );

--- a/src/components/__tests__/ChartTooltip.test.tsx
+++ b/src/components/__tests__/ChartTooltip.test.tsx
@@ -428,6 +428,13 @@ describe('ChartTooltip strip mode on a narrow chart', () => {
 describe('ChartTooltip expanding a capped readout', () => {
   const overflowing = { scrollHeight: 400, clientHeight: 100 };
   const original: Partial<Record<keyof typeof overflowing, PropertyDescriptor>> = {};
+  /**
+   * `scrollTop` is stubbed as a real read/write pair rather than a constant,
+   * because one of the cases below is about the readout *writing* it. jsdom's
+   * own is inert — it accepts a value and reports 0 back.
+   */
+  let scrollTop = 0;
+  let originalScrollTop: PropertyDescriptor | undefined;
 
   beforeEach(() => {
     for (const [property, value] of Object.entries(overflowing)) {
@@ -438,12 +445,24 @@ describe('ChartTooltip expanding a capped readout', () => {
         get: () => value,
       });
     }
+    scrollTop = 0;
+    originalScrollTop =
+      Object.getOwnPropertyDescriptor(Element.prototype, 'scrollTop') ?? undefined;
+    Object.defineProperty(Element.prototype, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+    });
   });
 
   afterEach(() => {
     for (const [property, descriptor] of Object.entries(original)) {
       if (descriptor) Object.defineProperty(Element.prototype, property, descriptor);
     }
+    if (originalScrollTop)
+      Object.defineProperty(Element.prototype, 'scrollTop', originalScrollTop);
   });
 
   const narrowPinned = { containerWidth: 479, plotHeight: 300, isPinned: true };
@@ -520,6 +539,105 @@ describe('ChartTooltip expanding a capped readout', () => {
   /** The floating box has no cap, so it is never scrolling and never asks. */
   it('is not offered on the floating box', () => {
     expect(toggleIn(boxOf({ ...narrowPinned, containerWidth: 600 }))).toBeNull();
+  });
+
+  /**
+   * The gesture the case above stops short of. "A different Month" in a real
+   * chart is also different *content* and, where the reader tapped away from a
+   * pin, a different pinned state — and the collapse used to arrive a frame
+   * after both, on a passive effect, so the measurement that decides whether to
+   * offer the control ran against the Month that had already gone.
+   *
+   * Said plainly, because it would otherwise be assumed: the two cases below
+   * fail if the collapse goes away, and pass either way on the *ordering*. RTL
+   * flushes passive effects inside `act`, so the extra frame the derivation
+   * removes has already been and gone by the time anything can be asserted. What
+   * is covered here is the content and pin-state change the case above holds
+   * fixed; the frame itself is only observable in a browser.
+   */
+  /**
+   * One event, not several. What is under the cap is measured rather than
+   * counted — that is this block's whole premise — and a Month holding more than
+   * one draws the carousel's own buttons, which `toggleIn` would then find
+   * alongside the control it is looking for.
+   */
+  const oneEvent = [makeTransitEvent({ id: 'a', date: '2020-06', title: 'Detour' })];
+
+  const atMonth = (index: number, props: Partial<Parameters<typeof ChartTooltip>[0]>) => (
+    <ChartTooltip
+      index={index}
+      months={months}
+      datasets={datasets}
+      events={[]}
+      caret={{ x: 100, y: 20 }}
+      {...narrowPinned}
+      {...props}
+    />
+  );
+
+  it('opens collapsed on a Month whose events changed with it', () => {
+    const { container, rerender } = render(atMonth(1, { events: oneEvent }));
+    const box = container.querySelector<HTMLElement>('[data-testid="chart-tooltip"]')!;
+    fireEvent.click(toggleIn(box) as HTMLElement);
+    expect(box.style.maxHeight).toBe('');
+
+    rerender(atMonth(2, { events: [] }));
+
+    // Collapsed and re-measured in one commit: the cap is back, and the control
+    // that lifts it is offered for *this* Month rather than withheld because the
+    // last one was open when it was measured.
+    expect(box.dataset.expanded).toBe('false');
+    expect(box.style.maxHeight).toBe('100px');
+    expect(toggleIn(box)?.textContent).toBe('Expand');
+  });
+
+  /**
+   * The reported gesture, at this component's level. Tapping another month
+   * releases the pin (ADR-0011), so the readout can arrive unpinned on the same
+   * rerender that changes the Month.
+   */
+  it('opens collapsed when the pin is released with the Month', () => {
+    const { container, rerender } = render(atMonth(1, { events: oneEvent }));
+    const box = container.querySelector<HTMLElement>('[data-testid="chart-tooltip"]')!;
+    fireEvent.click(toggleIn(box) as HTMLElement);
+
+    rerender(atMonth(2, { events: oneEvent, isPinned: false }));
+
+    expect(box.dataset.expanded).toBe('false');
+    expect(box.style.maxHeight).toBe('100px');
+  });
+
+  /**
+   * A capped box that is holding something back always says so. Unpinned it
+   * cannot offer a button — it does not accept the pointer — so it says the one
+   * thing that leads anywhere. Reachable only with a mouse on a chart under
+   * 480px, a narrow panel on a desktop; a pointer that cannot hover has no
+   * unpinned readout at all (see `RidershipChart`).
+   */
+  it('names the way out even where it cannot offer the control', () => {
+    const box = boxOf({ ...narrowPinned, events: oneEvent, isPinned: false });
+    expect(toggleIn(box)).toBeNull();
+    expect(within(box).getByText('Click to pin')).toBeTruthy();
+  });
+
+  it('does not say it where there is nothing under the cap', () => {
+    const box = boxOf({ ...narrowPinned, containerWidth: 600, isPinned: false });
+    expect(within(box).queryByText('Click to pin')).toBeNull();
+  });
+
+  /**
+   * React reuses this element across Months and the browser keeps a scrolling
+   * box's `scrollTop` when its content is replaced, so a reader who scrolled
+   * through a busy Month met the next one already past its heading.
+   */
+  it('starts a new Month at its heading', () => {
+    const { container, rerender } = render(atMonth(1, { events: oneEvent }));
+    const box = container.querySelector<HTMLElement>('[data-testid="chart-tooltip"]')!;
+    box.scrollTop = 40;
+
+    rerender(atMonth(2, { events: oneEvent }));
+
+    expect(box.scrollTop).toBe(0);
   });
 });
 

--- a/src/components/__tests__/RidershipChart.test.tsx
+++ b/src/components/__tests__/RidershipChart.test.tsx
@@ -85,18 +85,38 @@ const renderChart = (
   return { ...view, onPinnedMonthRequest, onRangeSelect };
 };
 
-/** Drives the tooltip's `external` handler the way a real hover would. */
-const hoverMonth = (index: number | null) =>
+/**
+ * Drives the tooltip's `external` handler the way a real hover would.
+ *
+ * `replay` is the third field Chart.js passes and its own types leave out: set,
+ * it marks the call as coming from `Chart#update` replaying `_lastEvent` rather
+ * than from the pointer. See `TooltipExternalArgs`.
+ */
+const hoverMonth = (index: number | null, { replay = false } = {}) =>
   act(() => {
     const external = capturedOptions?.plugins?.tooltip?.external as unknown as (
-      args: { tooltip: { opacity: number; dataPoints?: { dataIndex: number }[] } },
+      args: {
+        tooltip: { opacity: number; dataPoints?: { dataIndex: number }[] };
+        replay?: boolean;
+      },
     ) => void;
-    external(
-      index === null
+    external({
+      ...(index === null
         ? { tooltip: { opacity: 0 } }
-        : { tooltip: { opacity: 1, dataPoints: [{ dataIndex: index }] } },
-    );
+        : { tooltip: { opacity: 1, dataPoints: [{ dataIndex: index }] } }),
+      replay,
+    });
   });
+
+/** The props `renderChart` supplies, so a rerender can vary one of them. */
+const chartProps = (props: Partial<Parameters<typeof RidershipChart>[0]>) => ({
+  chartDatasets: [dataset],
+  months,
+  transitEvents: [opening],
+  pinnedMonth: null,
+  highlightedMonth: null,
+  ...props,
+});
 
 /**
  * `type` is load-bearing, not decoration. Chart.js dispatches `onClick` for
@@ -197,6 +217,119 @@ describe('RidershipChart hover', () => {
     hoverMonth(5);
     hoverMonth(null);
     expect(screen.queryByTestId('chart-tooltip')).toBeNull();
+  });
+
+  /**
+   * A repaint is not a gesture. `Chart#update` — which pinning a month causes —
+   * replays `_lastEvent`, and `determineLastEvent` keeps the previous event
+   * across a click, so an unguarded `external` sets the hover back to the month
+   * the reader has just left. That is the intermittent half of the readout going
+   * out of step with the month tapped.
+   */
+  it('ignores a hover replayed by a repaint', () => {
+    renderChart();
+    hoverMonth(5);
+    hoverMonth(1, { replay: true });
+    expect(readoutMonth()).toBe('Jun 2020');
+  });
+});
+
+/**
+ * A finger has no resting position, so there is no month it is over. Chart.js
+ * reports one anyway — a tap synthesises a `mousemove` — and nothing ever takes
+ * it back, because touch fires no `mouseout`.
+ *
+ * Left standing under a released pin, that stale hover turned the release-first
+ * rule (ADR-0011) into a trap on a phone: tapping another month released the
+ * pin, the readout stayed up in its *unpinned* form, and on a chart that narrow
+ * the unpinned form is a strip capped at a third of the plot with no Expand
+ * control, no full description and no source link. A box naming a month it could
+ * not show, and no way out of it.
+ *
+ * So a release takes the readout with it, on every pointer.
+ */
+describe('RidershipChart releasing a pin', () => {
+  /** The reported gesture: pinned, then "exit" by tapping another month. */
+  it('dismisses the readout rather than leaving an unpinned one', () => {
+    const { rerender, onPinnedMonthRequest } = renderChart({ pinnedMonth: '2020 6' });
+
+    // The tap on another month: its phantom hover, then the click that, under
+    // release-first, asks for the pin rather than for that month.
+    hoverMonth(3);
+    fakeChart.getElementsAtEventForMode.mockReturnValue([{ index: 3 }]);
+    clickChart(120);
+    expect(onPinnedMonthRequest).toHaveBeenCalledWith('2020 4');
+
+    // What `OutputArea` sends back for that request while something is pinned.
+    rerender(
+      <RidershipChart
+        {...chartProps({ pinnedMonth: null })}
+        onPinnedMonthRequest={onPinnedMonthRequest}
+      />,
+    );
+
+    // The ghost named directly, not only counted: an unpinned readout is one a
+    // touch reader can neither dismiss nor, at this width, read.
+    expect(screen.queryByTestId('chart-tooltip')).toBeNull();
+    expect(
+      document.querySelector('[data-testid="chart-tooltip"][data-pinned="false"]'),
+    ).toBeNull();
+  });
+
+  /** The Event Gutter is the other writer of the hovered month. Same answer. */
+  it('drops a hover the Event Gutter reported', () => {
+    const { rerender, onPinnedMonthRequest } = renderChart({ pinnedMonth: '2020 6' });
+    act(() => capturedOptions?.plugins?.eventGutter?.onGutterHover?.(3));
+
+    rerender(
+      <RidershipChart
+        {...chartProps({ pinnedMonth: null })}
+        onPinnedMonthRequest={onPinnedMonthRequest}
+      />,
+    );
+
+    expect(screen.queryByTestId('chart-tooltip')).toBeNull();
+  });
+
+  /**
+   * Only a *release* clears it. Taking a pin while hovering leaves the hover
+   * where it is, so the readout the mouse is over survives the pointer moving
+   * off and back — which is the behaviour a pin was always layered on top of.
+   */
+  it('keeps the hover when a pin is taken', () => {
+    const { rerender, onPinnedMonthRequest } = renderChart();
+    hoverMonth(3);
+
+    rerender(
+      <RidershipChart
+        {...chartProps({ pinnedMonth: '2020 6' })}
+        onPinnedMonthRequest={onPinnedMonthRequest}
+      />,
+    );
+    expect(readoutMonth()).toBe('Jun 2020');
+
+    rerender(
+      <RidershipChart
+        {...chartProps({ pinnedMonth: null })}
+        onPinnedMonthRequest={onPinnedMonthRequest}
+      />,
+    );
+    // Released, so the hover underneath went too — not back to April.
+    expect(screen.queryByTestId('chart-tooltip')).toBeNull();
+  });
+
+  /** A pointer that then moves gets its readout back, as it always did. */
+  it('lets the next movement bring one back', () => {
+    const { rerender, onPinnedMonthRequest } = renderChart({ pinnedMonth: '2020 6' });
+    rerender(
+      <RidershipChart
+        {...chartProps({ pinnedMonth: null })}
+        onPinnedMonthRequest={onPinnedMonthRequest}
+      />,
+    );
+    hoverMonth(3);
+    expect(readoutMonth()).toBe('Apr 2020');
+    expect(screen.getByTestId('chart-tooltip').dataset.pinned).toBe('false');
   });
 });
 


### PR DESCRIPTION
Follow-up to #214.

## The report

From a phone: pin a Month, tap **Expand**, then "exit" by tapping another Month. The readout ends up naming a Month whose content it does not show. Intermittent — "it fixes itself after tapping around."

Three defects on one gesture. No exception is thrown; it is a state bug.

| what you tapped | what you got |
| --- | --- |
| pinned May, expanded, tapped April | a readout headed **May 2026** with May's event nowhere on it, no Expand, and no way to reach either |

## 1. A release that released nothing

`OutputArea.requestPin` releases the pin when any Month is tapped while one is pinned (ADR-0011). A hover is meant to be transient and on a mouse it is — the next movement retargets it, `mouseout` ends it. A touch screen sends neither. A tap synthesises one `mousemove` and nothing ever takes it back, so `hoverIndex` on a phone is not *the Month under the pointer* but *the last Month touched*, permanently.

`activeIndex = pinnedIndex ?? keyboardIndex ?? hoverIndex` therefore never fell to null. The readout stayed up in its **unpinned** form — which drops the Expand control, re-clamps the description to three lines and hides the Source link — while the strip stayed capped at a third of the plot. On a 390px screen that cap is ~61px: the heading and two ridership rows. So the Month's event sat below the fold, with the control that would have lifted the cap removed by the same gesture, and the "Click to pin" hint at the foot of the box below the fold with it.

The context-log panel meanwhile banded no row, because nothing was pinned. Two views of one pin, disagreeing — which is the thing sharing the pin exists to prevent. ADR-0011 justifies the panel staying shut with *"the tooltip carries the event content in full"*; unpinned on a phone it carried none of it.

**Fix: releasing a pin clears the hover underneath it**, so the readout goes when the pin does. Adjusted during render rather than in an effect — React's own pattern for state that follows a prop — so the release and the cleared hover reach the reader in one paint.

### Why every pointer, and not just touch

The obvious version gates the hover on `matchMedia('(hover: none)')` and leaves the mouse alone. I wrote it that way first. **It does not work.** Instrumenting the chart and reading the value at render time, the same emulated Pixel 7 answers that query `false` on one render and `true` on the next, inside one session:

```
AFTER EXIT: {"pinnedIndex":null,"hoverIndex":12,"canHover":false,"activeIndex":null}
AFTER EXIT: {"pinnedIndex":null,"hoverIndex":12,"canHover":true,"activeIndex":12}
```

The e2e passed 2 runs in 3. A rule that has to hold cannot rest on an answer that wobbles, and the test proving it would be flaky in both directions. Clearing needs no such answer, and states one rule for every pointer.

**What that costs, and it is a real behaviour change:** on a mouse, releasing a pin without moving the pointer now takes the readout away rather than leaving a hovering one, until the pointer moves. Small, and arguably what "release" should have looked like — the reader clicking to dismiss gets a dismissal. Open question 1 below.

## 2. The intermittent half: two unguarded replay paths

#213 ("a repaint is not a gesture") gave `rangeSelect` an `args.replay` guard. Two other paths read pointer state and never got one.

`Chart#update` replays `_lastEvent`, and `determineLastEvent` keeps the *previous* event both across a click **and whenever the pointer is outside `chartArea`** — which the Event Gutter always is. Pinning a Month is a repaint, so the gutter re-answered the pin under release-first, and the tooltip put the hover back on the Month just left.

- `eventGutter.afterEvent` — the guard, before every branch.
- the tooltip's `external` — Chart.js passes `replay` here at runtime (`Tooltip#update` forwards it) but its published type declares only `{ chart, tooltip }`. That omission is why this one went unguarded longest, and why it needs a local widening rather than a module augmentation: `external` is a method signature, not a named argument type.

## 3. The expansion arrived a frame late, and the strip kept its scroll

`useEffect(() => setIsExpanded(false), [index])` is *passive*, so the first committed frame of a new Month still carried the previous Month's expansion — uncapped — and the `hasMore` measurement ran against that box before self-correcting. `isExpanded` is now derived from the Month it was expanded *for*, so the collapse and the Month arrive in the same render and there is no such frame.

Separately the strip is `overflow-y-auto` on an element React reuses across Months, so the browser carried `scrollTop` over: a reader scrolled through a busy Month met the next one already past its heading. Reset in a layout effect.

### Rebased over #224, and one thing that came with it

#224 landed the event carousel in the same component while this was in flight. Two consequences, both in the resolution rather than smuggled in:

- **The carousel's position gets the same treatment as the expansion.** #224 reset `eventIndex` in the very passive effect defect 3 is about — so a Month change painted one frame at the previous Month's position before snapping to "1 of N". It now states the Month it belongs to (`shownFor`), like the expansion, and nothing needs resetting. Behaviour is identical; the frame is gone and so is the effect. The render-time clamp #224 added is untouched and still doing its own job, which is a shrinking `events` under a held position.
- **My new cases use a one-event fixture.** A Month with two draws the carousel's buttons, which the block's existing `toggleIn` helper would find alongside the control it is looking for. One event is truer to the block anyway: what is under the cap is *measured*, not counted.

`step` already zeroed `scrollTop` between two events of one Month; defect 3's reset does the same thing between Months.

## Beyond what was reported

An unpinned capped strip now says **Click to pin** where Expand would be. It cannot offer a button — an unpinned readout is `pointer-events-none`, so a control there is one you can see and cannot press — but a capped box should never withhold content in silence. With defect 1 fixed, that state is reachable only with a mouse on a chart under 480px, i.e. a narrow panel on a desktop. Say the word and it comes out.

## Testing

- **Unit, 929 green.** `RidershipChart` gets the reported gesture end to end and its three neighbours: a release clears a gutter-reported hover too, *taking* a pin clears nothing, and the next movement brings a readout back. `eventGutter` gets a replayed click and a replayed hover. `ChartTooltip`'s expand block gains the cases the existing one held fixed — a Month change that also changes the events, one that also drops the pin, the `scrollTop` reset, and both states of the new hint.
- **Playwright** — `chart-interaction.spec.ts`, the deliberately snapshot-free sibling. A `mobileOnly` block taps a triangle at 390px, asserts the strip is pinned, taps Expand, then taps another Month and asserts **no readout at all**, plus no readout with `data-pinned="false"` and no banded log row.
- **Every new test verified able to fail.** Each guard reverted in turn, the failures observed, then restored. The touch e2e: 6/6 pass with the fix, 4/4 fail without.
- `npm run lint`, `npm run build`, 929 unit tests, 44 Playwright tests across `chart-interaction` + `context-logs` — all green. **No baseline screenshots change**; the count stays at 46.

### One thing the tests do not cover, said plainly

The *ordering* win in defect 3 — no frame painted uncapped — is not observable through React Testing Library, which flushes passive effects inside `act`. Those two cases fail if the collapse goes away and pass either way on the ordering; what they actually cover is the content and pin-state change the old case held fixed. Noted in the spec rather than left to be assumed. The `scrollTop` case does fail without its fix.

## Docs

- **ADR-0011** gains *"What release-first exposed: a release that released nothing"*, alongside the existing *"one gesture, two `onClick` dispatches"*. Not a new ADR — no new principle; this is the rule finishing. It records the media-query approach and why it was abandoned, and records the plausible alternative — decoupling Expand from the pin — so a later change argues with it rather than rediscovering it. Briefly: unpinned means clamped descriptions and no source links, so an expanded unpinned strip would mean "all of the shortened version", which is what `STRIP_HEIGHT_SHARE` rejected a second cap for.
- **`docs/how-it-works.md`** — the replay bullet closed with "anything new that reads pointer state needs the same guard", which was a warning two existing call sites were already violating. It now names all three, and records that Chart.js passes `replay` to `external` at runtime while declaring only two fields.
- **CONTEXT.md** — **Month Readout** and **Pinned Month** both state what a release does.
- One stale comment corrected in `chart-interaction.spec.ts`: the `re-pointing` block was desktop-only because the 256px box covered the triangle that opened it on a phone. #214's strip sits wholly above the plot, so that has not been true since.

## Open questions for the reviewer

1. **The desktop behaviour change.** Releasing a pin without moving the mouse now clears the readout entirely. Deliberate, and the reason one rule beats two, but it changes a surface nobody complained about.
2. **"Click to pin" in the header** is beyond the report — see above.
3. **The `TooltipExternalArgs` cast** asserts a field Chart.js documents in its source and omits from its types. The alternative is reaching into `chart._lastEvent`, which is worse. If Chart.js ever declares it, the cast should go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
