### PR TITLE
feat(stops): useStopView, and the gate on a 5.3 MB payload

### DIFF
--- a/src/hooks/__tests__/useStopView.test.ts
+++ b/src/hooks/__tests__/useStopView.test.ts
@@ -169,7 +169,7 @@ describe('useStopView', () => {
     expect(
       requested.filter((url) => url === '/stop-ridership.rail.json'),
     ).toHaveLength(1);
-    // And it is drawable again, not merely cached.
+    // The view draws the stop again, rather than merely holding it in cache.
     expect(result.current.view.readouts).toHaveLength(1);
   });
 

--- a/src/hooks/__tests__/useStopView.test.ts
+++ b/src/hooks/__tests__/useStopView.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import useStopView from '../useStopView';
+import { daysOfWeek } from '../../@types/metrics.types';
+import type { ColumnarStopRidership } from '../../@types/stops.types';
+
+/**
+ * The intent gate, which is the whole point of this hook.
+ *
+ * The bus payload is 5.3 MB. Everything asserted here is a rule about *not* fetching
+ * it: not before the panel is on, not when the Month Window has no stop data in it,
+ * and not when every selected line is already served by the 89 KB rail payload. The
+ * failure this guards is the one that would undo `OutputArea`'s lazy-load.
+ */
+
+const cols = [
+  'year',
+  'month',
+  'line',
+  'stop',
+  'wd_ons',
+  'wd_offs',
+  'sa_ons',
+  'sa_offs',
+  'su_ons',
+  'su_offs',
+];
+
+const railPayload: ColumnarStopRidership = {
+  schema: 1,
+  cols,
+  stops: [{ key: 'rail:union-station', name: 'Union Station' }],
+  rows: [[2025, 7, 801, 0, 100, 90, 60, 55, 40, 35]],
+};
+
+const busPayload: ColumnarStopRidership = {
+  schema: 1,
+  cols,
+  stops: [{ key: 'bus:vermont-wilshire', name: 'Vermont / Wilshire' }],
+  rows: [[2025, 7, 204, 0, 500, 450, 300, 280, 200, 180]],
+};
+
+const requested: string[] = [];
+
+const fetchMock = vi.fn((url: string) => {
+  requested.push(url);
+  const body = url.includes('rail') ? railPayload : busPayload;
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(body),
+  } as Response);
+});
+
+/** The window the fixture months sit inside. */
+const inWindow = { startDate: new Date(2025, 6), endDate: new Date(2026, 5) };
+/** A window years away from any stop data. */
+const outOfWindow = { startDate: new Date(2015, 0), endDate: new Date(2015, 11) };
+
+const baseInput = {
+  dayOfWeek: daysOfWeek.Weekday,
+  measure: 'ons' as const,
+  ...inWindow,
+};
+
+beforeEach(() => {
+  requested.length = 0;
+  fetchMock.mockClear();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useStopView', () => {
+  it('fetches nothing while the panel is off', async () => {
+    renderHook(() =>
+      useStopView({ ...baseInput, enabled: false, lineIds: [204] }),
+    );
+    await Promise.resolve();
+    expect(requested).toEqual([]);
+  });
+
+  it('yields the empty view before anything has loaded', () => {
+    const { result } = renderHook(() =>
+      useStopView({ ...baseInput, enabled: false, lineIds: [204] }),
+    );
+    expect(result.current.view.readouts).toEqual([]);
+    expect(result.current.records).toBeNull();
+  });
+
+  it('fetches rail as soon as the panel is on', async () => {
+    renderHook(() => useStopView({ ...baseInput, enabled: true, lineIds: [] }));
+    await waitFor(() =>
+      expect(requested).toContain('/stop-ridership.rail.json'),
+    );
+  });
+
+  it('leaves the bus payload alone when only rail lines are selected', async () => {
+    const { result } = renderHook(() =>
+      useStopView({ ...baseInput, enabled: true, lineIds: [801] }),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(requested).not.toContain('/stop-ridership.bus.json');
+  });
+
+  it('fetches bus once a line the rail payload does not serve is selected', async () => {
+    const { result } = renderHook(() =>
+      useStopView({ ...baseInput, enabled: true, lineIds: [204] }),
+    );
+    await waitFor(() =>
+      expect(requested).toContain('/stop-ridership.bus.json'),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  /**
+   * The window is not compared against anything here — `overlapsWindow` comes from
+   * `buildStopView`, which runs the one window predicate. This asserts the hook reads
+   * that answer before spending 5.3 MB.
+   */
+  it('does not fetch bus for a window with no stop data in it', async () => {
+    const { result } = renderHook(() =>
+      useStopView({
+        ...baseInput,
+        ...outOfWindow,
+        enabled: true,
+        lineIds: [204],
+      }),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(requested).not.toContain('/stop-ridership.bus.json');
+    expect(result.current.view.coverage.overlapsWindow).toBe(false);
+  });
+
+  it('still reports what the payload covers for a window it does not reach', async () => {
+    const { result } = renderHook(() =>
+      useStopView({
+        ...baseInput,
+        ...outOfWindow,
+        enabled: true,
+        lineIds: [204],
+      }),
+    );
+    await waitFor(() => expect(result.current.view.coverage.from).toBe('2025-07'));
+  });
+
+  it('fetches each payload once, however often the inputs change', async () => {
+    const { result, rerender } = renderHook(
+      (lineIds: number[]) =>
+        useStopView({ ...baseInput, enabled: true, lineIds }),
+      { initialProps: [204] },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    rerender([204, 801]);
+    rerender([801]);
+    rerender([204]);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(
+      requested.filter((url) => url === '/stop-ridership.bus.json'),
+    ).toHaveLength(1);
+    expect(
+      requested.filter((url) => url === '/stop-ridership.rail.json'),
+    ).toHaveLength(1);
+  });
+
+  it('keeps what it loaded when the panel is switched off and on again', async () => {
+    const { result, rerender } = renderHook(
+      (enabled: boolean) =>
+        useStopView({ ...baseInput, enabled, lineIds: [801] }),
+      { initialProps: true },
+    );
+    await waitFor(() => expect(result.current.records).not.toBeNull());
+
+    rerender(false);
+    rerender(true);
+
+    expect(
+      requested.filter((url) => url === '/stop-ridership.rail.json'),
+    ).toHaveLength(1);
+    // And it is drawable again, not merely cached.
+    expect(result.current.view.readouts).toHaveLength(1);
+  });
+
+  /**
+   * The cache is not the view.
+   *
+   * `records` deliberately survives the panel closing, so reopening it costs nothing. But
+   * the map draws its circles from `view.markers` whether or not the panel is open, so a
+   * view built from a live cache while the panel is off left circles on the map with no
+   * panel beneath them and no control still claiming to govern them.
+   */
+  it('yields the empty view while the panel is off, however much is cached', async () => {
+    const { result, rerender } = renderHook(
+      (enabled: boolean) =>
+        useStopView({ ...baseInput, enabled, lineIds: [801] }),
+      { initialProps: true },
+    );
+    await waitFor(() => expect(result.current.view.readouts).toHaveLength(1));
+    expect(result.current.view.markers.features.length).toBeGreaterThan(0);
+
+    rerender(false);
+
+    expect(result.current.view.readouts).toHaveLength(0);
+    expect(result.current.view.markers.features).toHaveLength(0);
+    // The payload itself is kept — that is what makes reopening free.
+    expect(result.current.records).not.toBeNull();
+  });
+
+  it('derives readouts for a selected line once its payload lands', async () => {
+    const { result } = renderHook(() =>
+      useStopView({ ...baseInput, enabled: true, lineIds: [801] }),
+    );
+    await waitFor(() => expect(result.current.view.readouts).toHaveLength(1));
+    expect(result.current.view.readouts[0].key).toBe('rail:union-station');
+    expect(result.current.view.readouts[0].averageBoardings).toBe(100);
+  });
+
+  it('surfaces a failed fetch rather than looking like an empty period', async () => {
+    fetchMock.mockImplementationOnce(() =>
+      Promise.reject(new Error('offline')),
+    );
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useStopView({ ...baseInput, enabled: true, lineIds: [801] }),
+    );
+
+    await waitFor(() => expect(result.current.hasFailed).toBe(true));
+    expect(result.current.isLoading).toBe(false);
+    consoleError.mockRestore();
+  });
+});

--- a/src/hooks/__tests__/useStopView.test.ts
+++ b/src/hooks/__tests__/useStopView.test.ts
@@ -4,14 +4,7 @@ import useStopView from '../useStopView';
 import { daysOfWeek } from '../../@types/metrics.types';
 import type { ColumnarStopRidership } from '../../@types/stops.types';
 
-/**
- * The intent gate, which is the whole point of this hook.
- *
- * The bus payload is 5.3 MB. Everything asserted here is a rule about *not* fetching
- * it: not before the panel is on, not when the Month Window has no stop data in it,
- * and not when every selected line is already served by the 89 KB rail payload. The
- * failure this guards is the one that would undo `OutputArea`'s lazy-load.
- */
+/** Every test here is a rule about *not* fetching the 5.3 MB bus payload. */
 
 const cols = [
   'year',
@@ -114,11 +107,7 @@ describe('useStopView', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
   });
 
-  /**
-   * The window is not compared against anything here — `overlapsWindow` comes from
-   * `buildStopView`, which runs the one window predicate. This asserts the hook reads
-   * that answer before spending 5.3 MB.
-   */
+  /** The hook reads `buildStopView`'s window answer before spending 5.3 MB (ADR-0009). */
   it('does not fetch bus for a window with no stop data in it', async () => {
     const { result } = renderHook(() =>
       useStopView({
@@ -184,14 +173,7 @@ describe('useStopView', () => {
     expect(result.current.view.readouts).toHaveLength(1);
   });
 
-  /**
-   * The cache is not the view.
-   *
-   * `records` deliberately survives the panel closing, so reopening it costs nothing. But
-   * the map draws its circles from `view.markers` whether or not the panel is open, so a
-   * view built from a live cache while the panel is off left circles on the map with no
-   * panel beneath them and no control still claiming to govern them.
-   */
+  /** The cache is not the view: closing the panel has to clear the map's circles too. */
   it('yields the empty view while the panel is off, however much is cached', async () => {
     const { result, rerender } = renderHook(
       (enabled: boolean) =>

--- a/src/hooks/useStopView.ts
+++ b/src/hooks/useStopView.ts
@@ -16,22 +16,8 @@ import type {
 } from '../@types/stops.types';
 
 /**
- * Fetching the stop payloads on intent, and handing the one derivation what it needs.
- *
- * The fetches live here rather than in `App` because `App`'s `/ridership.json` effect is
- * the first-paint path, and a 5.3 MB payload there would undo the lazy `OutputArea`. Only
- * `OutputArea` imports this hook, so every byte sits in that chunk or behind an `import()`.
- *
- * The gate: rail (89 KB) loads when the panel is on, small enough to answer "is there stop
- * data in this window" alone. Bus (5.3 MB) loads only when the panel is on, the window
- * overlaps coverage, and a selected line is not one rail serves. Stop locations (1.6 MB)
- * are `import()`ed into their own chunk. Each is fetched at most once and kept, and the
- * `AbortController`s live for the hook's lifetime.
- *
- * Which lines bus serves is read off the data, never hardcoded. The G (901) and J (910)
- * BRT lines arrive in the Bus workbook while the app lists them under the train filter, so
- * gating on "is this a bus line" would leave a G-Line-only reader with an empty panel. A
- * line in neither payload falls to the bus side — the safe direction of that error.
+ * Fetches the stop payloads only once something actually needs them, so the 5.3 MB bus
+ * file never loads for a reader who didn't ask for it.
  */
 
 const RAIL_URL = '/stop-ridership.rail.json';
@@ -54,24 +40,11 @@ export interface UseStopViewInput {
 export interface UseStopViewResult {
   /** The derivation's output. The empty view until the first payload lands. */
   view: StopView;
-  /**
-   * Every loaded record, unfiltered; `null` until the first payload lands. Returned
-   * because the per-stop series needs one stop's months and `StopView` carries readouts
-   * rather than records. The series is still aligned to `view.months`, so no consumer of
-   * this has to know what the month window is.
-   */
+  /** Every loaded record, unfiltered, for the per-stop series to slice. */
   records: StopRecord[] | null;
-  /**
-   * A payload this view still needs is in flight. Distinct from "the view is empty": a
-   * window outside coverage settles with no readouts and nothing loading, which is the
-   * empty state rather than a spinner that never stops.
-   */
+  /** A payload this view still needs is in flight, which is not the same as empty. */
   isLoading: boolean;
-  /**
-   * A payload the panel asked for did not arrive. Surfaced rather than swallowed, because
-   * a failed fetch and an out-of-window selection both leave the table empty and only one
-   * of them is worth retrying.
-   */
+  /** A payload didn't arrive, which is worth retrying where an empty table isn't. */
   hasFailed: boolean;
 }
 
@@ -105,9 +78,8 @@ export default function useStopView({
   const [busStatus, setBusStatus] = useState<LoadStatus>('idle');
 
   /**
-   * One controller per payload, aborted on unmount. A ref rather than an effect-scoped
-   * local because the effects below are gated on intent rather than on a dependency
-   * changing, so a re-run must not cancel the download the previous run started.
+   * One controller per payload, aborted on unmount and kept in a ref so a re-run can't
+   * cancel the download the previous one started.
    */
   const controllers = useRef<AbortController[]>([]);
   useEffect(
@@ -156,23 +128,15 @@ export default function useStopView({
     [rail, bus, locations],
   );
 
-  /**
-   * `null` until something has landed, which is the loading state `buildStopView` already
-   * understands: it yields the empty view rather than one asserting nobody reported.
-   */
+  /** `null` until something has landed, which `buildStopView` reads as the empty view. */
   const records: StopRecord[] | null = useMemo(() => {
     if (!rail && !bus) return null;
     return [...(rail?.records ?? []), ...(bus?.records ?? [])];
   }, [rail, bus]);
 
   /**
-   * The empty view whenever the panel is off, however much is cached. `records` survives
-   * the panel closing — that is the cache's point — but the map draws circles from
-   * `view.markers` whether the panel is open or not, so ungated, switching the panel off
-   * left circles on the map with no control governing them.
-   *
-   * Gated by handing `buildStopView` a `null` records list rather than building an empty
-   * view here, because the module already defines what an absent payload yields.
+   * The empty view whenever the panel is off, or the map would keep drawing circles no
+   * control governs.
    */
   const view = useMemo(
     () =>
@@ -189,10 +153,8 @@ export default function useStopView({
   );
 
   /**
-   * Is the 5.3 MB file worth fetching? `overlapsWindow` is read off the rail-only view
-   * rather than compared against the window here, because the window rule has exactly one
-   * statement (ADR-0009). Both payloads come from one pipeline run over the same archives,
-   * so rail's answer holds for bus: a window in 2015 costs one 89 KB request.
+   * Is the 5.3 MB file worth fetching? Rail's cheap answer stands in for bus's, and the
+   * window rule stays stated once (ADR-0009).
    */
   const wantsBus =
     enabled &&

--- a/src/hooks/useStopView.ts
+++ b/src/hooks/useStopView.ts
@@ -1,0 +1,231 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  attachStopLocations,
+  buildStopView,
+  decodeStopRidership,
+  type DecodedStopRidership,
+  type StopView,
+} from '../stops';
+import type { DayOfWeek } from '../@types/metrics.types';
+import type {
+  ColumnarStopRidership,
+  StopLocationsFile,
+  StopMeasure,
+  StopPlace,
+  StopRecord,
+} from '../@types/stops.types';
+
+/**
+ * Fetching the stop payloads on intent, and handing the one derivation what it needs.
+ *
+ * The fetches live here rather than in `App` because `App`'s `/ridership.json` effect is
+ * the first-paint path, and a 5.3 MB payload there would undo the lazy `OutputArea`. Only
+ * `OutputArea` imports this hook, so every byte sits in that chunk or behind an `import()`.
+ *
+ * The gate: rail (89 KB) loads when the panel is on, small enough to answer "is there stop
+ * data in this window" alone. Bus (5.3 MB) loads only when the panel is on, the window
+ * overlaps coverage, and a selected line is not one rail serves. Stop locations (1.6 MB)
+ * are `import()`ed into their own chunk. Each is fetched at most once and kept, and the
+ * `AbortController`s live for the hook's lifetime.
+ *
+ * Which lines bus serves is read off the data, never hardcoded. The G (901) and J (910)
+ * BRT lines arrive in the Bus workbook while the app lists them under the train filter, so
+ * gating on "is this a bus line" would leave a G-Line-only reader with an empty panel. A
+ * line in neither payload falls to the bus side — the safe direction of that error.
+ */
+
+const RAIL_URL = '/stop-ridership.rail.json';
+const BUS_URL = '/stop-ridership.bus.json';
+
+/** Nothing requested yet · in flight · here · gave up. */
+type LoadStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface UseStopViewInput {
+  /** The stop panel is on. Nothing is fetched until it is. */
+  enabled: boolean;
+  /** Selected line ids, in the order readouts and markers should follow. */
+  lineIds: readonly number[];
+  startDate: Date;
+  endDate: Date;
+  dayOfWeek: DayOfWeek;
+  measure: StopMeasure;
+}
+
+export interface UseStopViewResult {
+  /** The derivation's output. The empty view until the first payload lands. */
+  view: StopView;
+  /**
+   * Every loaded record, unfiltered; `null` until the first payload lands. Returned
+   * because the per-stop series needs one stop's months and `StopView` carries readouts
+   * rather than records. The series is still aligned to `view.months`, so no consumer of
+   * this has to know what the month window is.
+   */
+  records: StopRecord[] | null;
+  /**
+   * A payload this view still needs is in flight. Distinct from "the view is empty": a
+   * window outside coverage settles with no readouts and nothing loading, which is the
+   * empty state rather than a spinner that never stops.
+   */
+  isLoading: boolean;
+  /**
+   * A payload the panel asked for did not arrive. Surfaced rather than swallowed, because
+   * a failed fetch and an out-of-window selection both leave the table empty and only one
+   * of them is worth retrying.
+   */
+  hasFailed: boolean;
+}
+
+/** Fetch, decode, and hand back — or `null` if the request was aborted or failed. */
+async function loadPayload(
+  url: string,
+  signal: AbortSignal,
+): Promise<DecodedStopRidership | null> {
+  const response = await fetch(url, { signal });
+  if (!response.ok)
+    throw new Error(`${url} responded ${String(response.status)}`);
+  return decodeStopRidership((await response.json()) as ColumnarStopRidership);
+}
+
+/** Still outstanding — neither loaded nor given up on. */
+const isPending = (status: LoadStatus): boolean =>
+  status !== 'ready' && status !== 'error';
+
+export default function useStopView({
+  enabled,
+  lineIds,
+  startDate,
+  endDate,
+  dayOfWeek,
+  measure,
+}: UseStopViewInput): UseStopViewResult {
+  const [rail, setRail] = useState<DecodedStopRidership | null>(null);
+  const [bus, setBus] = useState<DecodedStopRidership | null>(null);
+  const [locations, setLocations] = useState<StopLocationsFile | null>(null);
+  const [railStatus, setRailStatus] = useState<LoadStatus>('idle');
+  const [busStatus, setBusStatus] = useState<LoadStatus>('idle');
+
+  /**
+   * One controller per payload, aborted on unmount. A ref rather than an effect-scoped
+   * local because the effects below are gated on intent rather than on a dependency
+   * changing, so a re-run must not cancel the download the previous run started.
+   */
+  const controllers = useRef<AbortController[]>([]);
+  useEffect(
+    () => () => {
+      for (const controller of controllers.current) controller.abort();
+    },
+    [],
+  );
+
+  // Rail, plus the geometry both payloads join against. Panel on is the whole gate.
+  useEffect(() => {
+    if (!enabled || railStatus !== 'idle') return;
+    setRailStatus('loading');
+
+    const controller = new AbortController();
+    controllers.current.push(controller);
+
+    void (async () => {
+      try {
+        const [decoded, locationsModule] = await Promise.all([
+          loadPayload(RAIL_URL, controller.signal),
+          import('../data/stop_locations.json'),
+        ]);
+        setLocations(locationsModule.default as StopLocationsFile);
+        setRail(decoded);
+        setRailStatus('ready');
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error('Failed to load rail stop ridership', error);
+        setRailStatus('error');
+      }
+    })();
+  }, [enabled, railStatus]);
+
+  const railLineIds = useMemo(
+    () => new Set((rail?.records ?? []).map((record) => record.line_name)),
+    [rail],
+  );
+
+  const places: StopPlace[] = useMemo(
+    () =>
+      attachStopLocations(
+        [...(rail?.places ?? []), ...(bus?.places ?? [])],
+        locations,
+      ),
+    [rail, bus, locations],
+  );
+
+  /**
+   * `null` until something has landed, which is the loading state `buildStopView` already
+   * understands: it yields the empty view rather than one asserting nobody reported.
+   */
+  const records: StopRecord[] | null = useMemo(() => {
+    if (!rail && !bus) return null;
+    return [...(rail?.records ?? []), ...(bus?.records ?? [])];
+  }, [rail, bus]);
+
+  /**
+   * The empty view whenever the panel is off, however much is cached. `records` survives
+   * the panel closing — that is the cache's point — but the map draws circles from
+   * `view.markers` whether the panel is open or not, so ungated, switching the panel off
+   * left circles on the map with no control governing them.
+   *
+   * Gated by handing `buildStopView` a `null` records list rather than building an empty
+   * view here, because the module already defines what an absent payload yields.
+   */
+  const view = useMemo(
+    () =>
+      buildStopView({
+        records: enabled ? records : null,
+        places,
+        lineIds,
+        startDate,
+        endDate,
+        dayOfWeek,
+        measure,
+      }),
+    [enabled, records, places, lineIds, startDate, endDate, dayOfWeek, measure],
+  );
+
+  /**
+   * Is the 5.3 MB file worth fetching? `overlapsWindow` is read off the rail-only view
+   * rather than compared against the window here, because the window rule has exactly one
+   * statement (ADR-0009). Both payloads come from one pipeline run over the same archives,
+   * so rail's answer holds for bus: a window in 2015 costs one 89 KB request.
+   */
+  const wantsBus =
+    enabled &&
+    railStatus === 'ready' &&
+    view.coverage.overlapsWindow &&
+    lineIds.some((id) => !railLineIds.has(id));
+
+  useEffect(() => {
+    if (!wantsBus || busStatus !== 'idle') return;
+    setBusStatus('loading');
+
+    const controller = new AbortController();
+    controllers.current.push(controller);
+
+    void (async () => {
+      try {
+        setBus(await loadPayload(BUS_URL, controller.signal));
+        setBusStatus('ready');
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error('Failed to load bus stop ridership', error);
+        setBusStatus('error');
+      }
+    })();
+  }, [wantsBus, busStatus]);
+
+  const isLoading =
+    enabled && (isPending(railStatus) || (wantsBus && isPending(busStatus)));
+
+  return {
+    view,
+    records,
+    isLoading,
+    hasFailed: railStatus === 'error' || busStatus === 'error',
+  };
+}

--- a/src/hooks/useStopView.ts
+++ b/src/hooks/useStopView.ts
@@ -27,7 +27,7 @@ const BUS_URL = '/stop-ridership.bus.json';
 type LoadStatus = 'idle' | 'loading' | 'ready' | 'error';
 
 export interface UseStopViewInput {
-  /** The stop panel is on. Nothing is fetched until it is. */
+  /** The hook fetches nothing until the stop panel is on. */
   enabled: boolean;
   /** Selected line ids, in the order readouts and markers should follow. */
   lineIds: readonly number[];
@@ -38,7 +38,7 @@ export interface UseStopViewInput {
 }
 
 export interface UseStopViewResult {
-  /** The derivation's output. The empty view until the first payload lands. */
+  /** The derivation's output, which is the empty view until the first payload lands. */
   view: StopView;
   /** Every loaded record, unfiltered, for the per-stop series to slice. */
   records: StopRecord[] | null;
@@ -48,7 +48,7 @@ export interface UseStopViewResult {
   hasFailed: boolean;
 }
 
-/** Fetch, decode, and hand back — or `null` if the request was aborted or failed. */
+/** Fetches one payload and decodes it, throwing if the response is not ok. */
 async function loadPayload(
   url: string,
   signal: AbortSignal,
@@ -59,7 +59,7 @@ async function loadPayload(
   return decodeStopRidership((await response.json()) as ColumnarStopRidership);
 }
 
-/** Still outstanding — neither loaded nor given up on. */
+/** The payload has neither loaded nor been given up on. */
 const isPending = (status: LoadStatus): boolean =>
   status !== 'ready' && status !== 'error';
 
@@ -89,7 +89,7 @@ export default function useStopView({
     [],
   );
 
-  // Rail, plus the geometry both payloads join against. Panel on is the whole gate.
+  // Turning the panel on fetches rail and the geometry both payloads join against.
   useEffect(() => {
     if (!enabled || railStatus !== 'idle') return;
     setRailStatus('loading');
@@ -135,8 +135,8 @@ export default function useStopView({
   }, [rail, bus]);
 
   /**
-   * The empty view whenever the panel is off, or the map would keep drawing circles no
-   * control governs.
+   * The view goes empty whenever the panel is off, or the map would keep drawing circles
+   * no control governs.
    */
   const view = useMemo(
     () =>
@@ -153,7 +153,7 @@ export default function useStopView({
   );
 
   /**
-   * Is the 5.3 MB file worth fetching? Rail's cheap answer stands in for bus's, and the
+   * Rail's cheap answer decides whether the 5.3 MB bus file is worth fetching, so the
    * window rule stays stated once (ADR-0009).
    */
   const wantsBus =


### PR DESCRIPTION
## Where this sits

Second of six. Two files and no consumer, because the whole PR is one question: **does the fetch gate hold.** `useStopView` feeds the stop panel, and it is separated out because the gate it implements is the only thing standing between a reader and a 5.3 MB download they did not ask for, which is worth reading on its own rather than at the bottom of a PR full of table markup.

| | | |
|---|---|---|
| 1 | the URL contract and the Stop Ridership checkbox | #235 |
| 2 | `useStopView` — the fetch gate on a 5.3 MB payload, no UI | #236 |
| 3 | the panel, the ranked table, the coverage notice | #231 |
| 4 | the ridership-over-time column | #232 |
| 5 | the stop series chart and its colour rule | #233 |
| 6 | the map's circle layer | #234 |

The two ADRs the batch owed — 0012 (the stop wire format) and 0013 (a stop's identity is its normalised name) — went out separately as #237 off `main`, since both record decisions #173 and #190 already made.

## What this changes

Rail (89 KB) loads when the panel is on, being small enough to answer "is there stop data in this window" by itself. Bus (5.3 MB) loads only when the panel is on, **and** the window overlaps coverage, **and** a selected line is not one rail serves. Stop locations (1.6 MB) go behind an `import()` into their own chunk. Each is fetched at most once and kept, and the `AbortController`s live for the hook's lifetime. The fetches live here rather than in `App` because `App`'s `/ridership.json` effect is the first-paint path, and a multi-megabyte payload there would undo the lazy `OutputArea` the next PR imports this from.

## What to check

- `useStopView.ts:117` — which lines bus serves is read off the data, never hardcoded. G (901) and J (910) BRT arrive in the Bus workbook while the app lists them under the train filter, so gating on "is this a bus line" would leave a G-Line-only reader with an empty panel. A line in neither payload falls to the bus side, which is the safe direction of that error.
- `useStopView.ts:46` — `isLoading` means *a payload this view still needs is in flight*, not *the view is empty*. A window outside coverage settles with no readouts and nothing loading, which is an empty state rather than a spinner that never stops.
- `useStopView.ts:48` — `hasFailed` is surfaced rather than swallowed, because a failed fetch and an out-of-window selection both leave the table empty and only one of them is worth retrying.
- The other half of the payload-fate rule — the panel guarding every takeover state on `!hasReadouts`, so neither payload can blank a table already on screen — lands in #231. The two were authored as one rule and are split across two PRs only for size, so read them together.
- `useStopView.ts:84,97` — the controllers array and the per-effect controller. Worth confirming nothing aborts a fetch whose result is still wanted.

## Before you merge

<!-- Commands were current on 2026-08-22; CONTRIBUTING.md is authoritative if they have drifted. -->

- [x] `npx tsc -b`, `npm run lint` and `npm run build` clean; Vitest 993 passed across 36 files
- [x] #231, #235, #237 and the rest of the stack linked above
- [x] No exported symbol renamed or deleted
- [x] No diagram source changed
- [x] Renders nothing — no baselines, no screenshot. `ANALYZE=1 npm run build` gives entry and `OutputArea` chunk hashes byte-identical to the PR below (`index-CAqBhEpl.js`, `OutputArea-uz_VfLPa.js`), since nothing imports this yet and it reaches no chunk at all
- [x] ADR-0012 and ADR-0013 carry the batch's decisions, via #237
