### PR TITLE
docs(adr): record the stop wire format and stop identity

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,8 @@ Then read whichever guide matches what you're about to do. Don't read them all.
 | [0009](adr/0009-the-two-window-rules-are-one-rule.md) | One window rule, inclusive on both ends — the chart's two-month offset is gone | accepted, **supersedes 0001** |
 | [0010](adr/0010-the-event-gutter-hit-tests-itself.md) | The Event Gutter hit-tests itself, because Chart.js will not | accepted |
 | [0011](adr/0011-a-pin-marks-it-never-moves-a-view.md) | A pin marks what is read; it never moves what is shown — release before taking, and no auto-move | accepted, fully landed — #200 removed the auto-move, #199 made the pin release first |
+| [0012](adr/0012-the-stop-payload-is-columnar-dictionary-encoded-and-versioned.md) | The stop payload is columnar, dictionary-encoded and versioned, one file per mode — columns by name, unknown schema rejected | accepted |
+| [0013](adr/0013-a-stops-identity-is-its-normalised-name.md) | A stop's identity is its normalised name, not a number — `station_order` is an ordering attribute only | accepted |
 
 ## Not for humans
 

--- a/docs/adr/0012-the-stop-payload-is-columnar-dictionary-encoded-and-versioned.md
+++ b/docs/adr/0012-the-stop-payload-is-columnar-dictionary-encoded-and-versioned.md
@@ -1,0 +1,100 @@
+# The stop payload is columnar, dictionary-encoded and versioned, with one file per mode
+
+Status: accepted
+
+Stop-grain ridership is two orders of magnitude larger than line grain: 105,984 rows and 6,785 stops
+in `stop_ridership.bus.json` against ~42,000 line-grain records, 5.3 MB as committed. It is generated
+data that lives in the repository, is fetched at runtime rather than bundled, and is reviewed as a
+diff every month when a new export lands. Those three facts together fixed its shape.
+
+The format is a four-key envelope. The committed fixtures at `vite/__fixtures__/stops/*.json` are the
+spec, and this is one row of it:
+
+```json
+{"schema": 1,
+ "cols": ["year", "month", "line", "stop", "wd_ons", "wd_offs", "sa_ons", "sa_offs", "su_ons", "su_offs"],
+ "stops": [{"key": "rail:union-station", "name": "Union Station", "station_order": 1026}],
+ "rows": [[2025, 8, 802, 0, 9000, 8800, 6000, 5900, 4000, 3900]]}
+```
+
+## The four decisions inside that shape
+
+**Columnar, because a key repeated 106,000 times is most of the payload.** `cols` names each field
+once and every row is a positional tuple. Line grain makes the same trade, but arrives differently:
+`ridership.json` is committed as pretty records and re-encoded columnar at build time, while the stop
+files are written columnar by Python and served as-is. Pretty records at stop grain would be roughly
+25 MB rewritten in full on every monthly ingest — repository growth rather than taste.
+
+**A stops dictionary, because the identity is the expensive part of a row.** `stop_key`, `stop_name`
+and `station_order` live once each in `stops`, and a row carries an integer index into it. A stop key
+averages around twenty characters and would otherwise appear in all 106,000 rows.
+
+**Resolved by name, never by position.** `src/stops/stopData.ts` reads every column through
+`columnIndex`, which throws and names the missing column rather than yielding `undefined`. That lets
+the pipeline reorder or extend `cols` without a client change, and it is the difference between a
+build that stops and a map drawn from a column of `NaN`s — or alightings rendered as boardings, which
+is plausible enough to survive review.
+
+**Versioned, and an unknown version is rejected outright.** `decodeStopRidership` throws when
+`data.schema !== STOP_WIRE_SCHEMA`, because decoding what we recognise and hoping is how a payload
+whose meaning has changed gets rendered as though it hadn't. `WIRE_SCHEMA` cannot move without the
+decoder moving with it.
+
+## One file per mode, and mode is not a column
+
+There are two payloads, `bus` and `rail`, and neither carries a `mode` column; the client derives mode
+from the stop key's prefix through `modeFromStopKey`. Splitting the files keeps a rail-only reader off
+the 5.3 MB bus payload, and an e2e case asserts that selecting a rail line never requests it.
+
+**The split is by source export, not by app mode**, and that is load-bearing. G Line (901) and J Line
+(910) BRT arrive in Metro's *Bus* workbook, so `stop_ridership.bus.json` carries lines the app shows
+under its train filter. The client's mode filter keys off `metro_line_metadata_current.json` and never
+off which file a row came from.
+
+`modeFromStopKey` is total rather than strict: an unrecognised prefix falls back to `Bus`. Mode there
+chooses only which magnitude domain a radius normalises against, so a wrong answer makes one circle
+the wrong size while throwing would take the whole panel down over one malformed key.
+
+## What the format costs, and what it buys back
+
+**A schema bump moves both halves** — the Python writer and the TypeScript decoder together. That is
+the intended cost of rejecting unknown versions.
+
+**`station_order` rides along in the dictionary and is not an identity.** It is a per-route sequence,
+so one station carries a different number on every route calling there, and the dictionary keeps the
+smallest. Ordering attribute only — see [ADR-0013](0013-a-stops-identity-is-its-normalised-name.md).
+
+**The file stays readable.** One JSON array per line: not pretty-printed, where indentation would be
+most of the file, and not one long line either. A newline per row costs about 2% and buys a diff that
+shows which months and which stops moved, which is the only review a multi-megabyte data file gets.
+Rows are sorted by `["year", "month", "line", "stop_key"]` and the dictionary by key, so a re-ingest
+over unchanged archives produces byte-identical output.
+
+**An absent payload is a supported state.** `vite/stop-ridership-plugin.ts` serves nothing and reports
+zero coverage when a file is missing, because a fresh clone before the first ingest has none, and
+neither does a branch landing the client ahead of the data. A *malformed* file still throws: absent is
+a state, corrupt is a bug.
+
+**The manifest exists so the panel need not fetch to find out what it has.**
+`virtual:stop-ridership-manifest` carries `minMonth`, `maxMonth`, `monthCount` and the two byte
+counts, which is how the Stop Coverage Window can be stated before megabytes are on the wire.
+
+## Alternatives
+
+**An array of `{year, month, line, stop_key, …}` objects**, as line grain is committed. Rejected on
+size: the 25 MB rewrite above, every month, in a repository that keeps its generated data.
+
+**A binary format — Arrow, protobuf, CBOR.** Smaller and faster to parse, and rejected because it
+would make the committed dataset unreviewable. The monthly diff is the only review these numbers get,
+and a binary blob turns "which stops moved" into an unanswerable question. This app has no backend, so
+there is nowhere to put an opaque artefact a human never has to read.
+
+**One combined payload with a `mode` column.** Simpler to write, and it would put 5.3 MB of bus data
+in front of every reader who opened the panel on a rail line.
+
+**Positional columns with no `cols` header.** Marginally smaller, and it makes a pipeline column
+reorder a silent data corruption instead of a loud build failure.
+
+**No `schema` key, with compatibility inferred from the columns present.** Column presence answers
+whether a field exists, never whether its *meaning* changed — a rounding rule or a null convention can
+move without any column moving.

--- a/docs/adr/0013-a-stops-identity-is-its-normalised-name.md
+++ b/docs/adr/0013-a-stops-identity-is-its-normalised-name.md
@@ -1,0 +1,94 @@
+# A stop's identity is its normalised name, not a number
+
+Status: accepted
+
+Metro's station-level exports name a place twice and identify it never. Each leaf row carries a stop or
+station name, and rail rows carry a `STATION_ORDER` value with a numeric prefix —
+`"1001-Downtown Long Beach Station"`. There is no stable id anywhere in the export. Something had to
+become the identity a series is keyed by, a URL carries and the map joins geometry on, so we mint one:
+
+```
+stop_key(mode, name) → "bus:vermont-wilshire", "rail:union-station"
+```
+
+The key is the mode prefix, a colon, and the normalised display name slugified — case-folded,
+whitespace collapsed, ` / ` unified, and for rail the platform suffix removed, so
+`"Union Station - A Line"` and `"Union Station"` are one place. `scripts/stop_identity.py` owns every
+part of that, and a hand-maintained alias table completes it.
+
+## Why not the number that looks like an id
+
+`STATION_ORDER`'s prefix is **a per-route sequence**, so one station carries a different number on
+every route calling there. In 2025-12 Union Station is `1026` on the A Line, `4001` on the B and `5001`
+on the D — same station, same month, three numbers. There is no join to be made on that value, so a
+payload keyed by it would report one station as three.
+
+The sequence space also moves as the network does. Rail leaf rows went 112 → 124 at 2025-09, when the
+A Line's Foothill extension opened and ROUTE 805 was first reported separately from 802, then 124 →
+127 at 2026-05 with the D Line extension. Those additions happened to be appended rather than
+inserted, so no existing number shifted across 2025-07 → 2026-05 — an observation about eleven months,
+not a property of the data.
+
+So `station_order` survives in the payload as an **ordering attribute and never an identity**; the
+dictionary keeps the smallest number a station carries, purely so a rail table can be listed in route
+order.
+
+## What the name-as-identity costs
+
+**A rename splits one series in two, silently, unless something catches it.** That is the real price,
+and it is paid twice over.
+
+The first payment is the guard. `stop_ridership.detect_renames` fails an ingest when a key first
+appears in a month that is not the dataset's first *and* an existing key disappears in that same
+month, printing both lists. Without it a Metro rename would draw two dots on the map and list both
+halves at half their real boardings, with nothing saying so. Both halves of the test are precise so
+ordinary service changes do not trip it: *appears* means absent from every earlier month, *disappears*
+means absent from this month and every later one, so a stop that skips a month and returns is not a
+disappearance.
+
+The second is `scripts/stop_aliases.json`, which folds one spelling onto the canonical slug and makes
+the signal go away along with the split it reported. It is hand-edited pipeline input, never shipped
+to the client, and chains are followed so a stop renamed twice still lands on one key. The rail table
+holds ten entries, all GTFS-side mismatches added by the geometry join; the bus table is empty,
+checked across every archive in `data/raw/`.
+
+**One case is ambiguous and deliberately left unaliased.** On line 28, `bus:san-vicente-fairfax` runs
+2025-07 → 2025-12 and `bus:san-vicente-orange-grove` runs 2025-12 → 2026-05: same corridor, comparable
+boardings, one month of overlap. That is either a rename or a stop that moved two blocks, and the data
+cannot say which, so aliasing would merge two series on a guess.
+
+**Two genuinely different places sharing a normalised name on one mode collapse into one key.**
+Nothing in the pipeline can tell that apart from one place spelled two ways, which is the same
+limitation from the other side. Modes are namespaced precisely because names collide across them
+freely — "Union Station" is both a bus stop and a rail station.
+
+## What it buys
+
+**Keys are URL-safe by construction**, matching `^(bus|rail):[a-z0-9-]+$`. That is what lets a Stop
+Selection go into a query string unencoded and read back as itself, and what lets a key sit in a
+`data-qa` attribute without escaping. A surrogate integer would have been shorter and unreadable: a
+shared link carrying `stop=4172` tells its recipient nothing.
+
+**The name is the one field every source has.** The ridership export, the GTFS feed and the reader all
+speak names, so the join between ridership and geometry is a name join whatever the key looks like.
+The alias table exists because that join is imperfect — but it would exist for any key derived from a
+name, and no other key was available to derive.
+
+## Alternatives
+
+**GTFS `stop_id`.** Stable, opaque, and absent from the ridership export — reaching it would still
+mean matching on the name first, which puts the same imperfect join under a key that merely looks
+authoritative. It would also make a stop with no GTFS match unidentifiable, and those stops are kept
+rather than dropped: they have ridership, so they belong in the table and the series even when the map
+cannot place them.
+
+**`STATION_ORDER`'s numeric prefix.** Discussed above. It is not an identity, and it is the trap this
+ADR exists to mark: a future reader will see a number in the payload and reasonably assume it is one.
+
+**A surrogate id minted at first sighting and stored in a committed registry.** Moves the whole problem
+into the registry, whose entries can only be created by matching a name and which would silently mint
+a second id for a renamed stop exactly as a name key does. It buys stability against re-slugging,
+which nothing needs, and costs readability in the URL, which the shared link needs.
+
+**A rounded `(lat, lon)`.** Available only for stops GTFS knows, which is not all of them, and it makes
+identity depend on a coordinate revision.


### PR DESCRIPTION
## Where this sits

`docs/adr/`, off `main` rather than inside the six-PR stop-panel stack. Both ADRs describe work that is already merged, so keeping them out of the stack means they can merge whenever and the stack's diffs stay code-only.

## What this changes

Two decisions have been load-bearing since #180 and #190 with no ADR, having lived only in `scripts/README.md` and module comments. Neither records a new decision — both were made in #173 and #190. **0012: the stop payload is columnar, dictionary-encoded and versioned**, one file per mode, columns resolved by name, an unknown `schema` rejected outright rather than best-effort decoded, with the committed fixtures at `vite/__fixtures__/stops/*.json` as the spec. **0013: a stop's identity is its normalised name, not a number** — `STATION_ORDER`'s numeric prefix is a per-route sequence that renumbered when the D Line extension landed, so `stop_key(mode, name)` mints `bus:vermont-wilshire` / `rail:union-station` and `scripts/stop_identity.py` owns every part of the normalisation. The stop-ridership plan reserved 0008/0009 for these; unrelated work took those numbers while the batch was in flight, so they land at 0012/0013 and the numbering runs out of order.

## What to check

- `0012...md:20` — the four decisions inside the format, and `:43` on why mode is a file rather than a column. Check these against what the loader actually does, since the ADR is written from merged code rather than ahead of it.
- `0013...md:19` — the case against the number that looks like an id. This is the one a future reader is most likely to try to reverse.
- `docs/README.md` — one row appended to the ADR table. `docs/adr-layout-lifetime` (0015) and #233 (0014) append to the same table, and the conflict resolves by keeping all three rows.

## Before you merge

<!-- Commands were current on 2026-08-22; CONTRIBUTING.md is authoritative if they have drifted. -->

- [x] Docs only — no code touched, so `lint` / `test` / `build` have nothing to gate
- [x] #173, #180 and #190 linked above
- [x] No exported symbol renamed or deleted
- [x] No diagram source changed
- [x] No UI change
- [x] These ADRs *are* the record
