### PR TITLE
docs: a PR template with four sections, and the writing principles behind it

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,30 @@
-## What and why
+## Where this sits
 
-<!-- What changes, and what problem it solves. Link the issue. -->
+<!-- Optional — delete this section when the PR touches one obvious place. One paragraph: which
+     part of the codebase this changes, and how it fits into the bigger picture. -->
 
-## Checklist
+## What this changes
+
+<!-- One paragraph: what the change does and why it's worth doing. Link the issue. If this PR
+     does two things, say why they're in one PR. -->
+
+## What to check
+
+<!-- A paragraph's worth at most — one bullet per behaviour a reviewer should verify, with
+     `file:line` pointers. Not a file inventory; the Files changed tab already lists those. -->
+
+## Before you merge
+
+<!-- Commands were current on 2026-08-22; CONTRIBUTING.md is authoritative if they have drifted. -->
 
 - [ ] `npm run lint`, `npm run test` and `npm run build` pass
+- [ ] Issue linked above
 - [ ] Renamed or deleted an exported symbol? Grepped `README.md`, `CONTEXT.md`, `CLAUDE.md` and
       `docs/` for it — including `docs/architecture/mermaid/` and `captions.md`
 - [ ] Changed a diagram source? Ran `npm run docs:architecture` and committed `diagrams.md`
 - [ ] Changed the UI? Screenshot below, and Linux baselines regenerated with
       `npm run test:e2e:update:linux`
+- [ ] Made a decision that looks wrong without the reasoning? Wrote an ADR in `docs/adr/`
 
 <!--
 Baselines: only the -linux.png set is committed and it is what gates CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,38 @@
 
 Start with [`README.md`](README.md) and [`docs/README.md`](docs/README.md) if you haven't.
 
+## Write so the next reader can skim
+
+These apply to everything that lands in the repo — code, comments, docs, commit bodies and PR
+descriptions — and they apply the same whether a person or an agent wrote it.
+
+- **Every fact lives in exactly one place.** The docs rule below is that principle applied to
+  `docs/`; it is why a document links rather than repeats.
+- **Headings and ADR titles are assertions, not labels.** "Push neither creates nor drops what its
+  schema does not describe" tells the reader whether to keep reading. "Push notes" does not.
+- **Say it plainly, once.** Short words, short sentences. Cut a sentence whose only job is to
+  introduce the next one.
+- **Keep the causal connective.** A *because* or *so that* stays whole, because dropping it turns
+  one explanation into two unrelated facts and leaves the reader to re-derive the link.
+- **Length is a cost, not proof of effort.** A long description is read less carefully than a short
+  one, so padding a section to look thorough makes review worse rather than better.
+
+## Open the PR with the template filled in
+
+[`.github/pull_request_template.md`](.github/pull_request_template.md) has four sections — where
+the change sits, what it changes, what to check, and the pre-merge checklist.
+
+- **One paragraph per section, maximum.** If a section needs more than that, the PR is
+  probably two PRs, or the explanation belongs in an ADR the description can cite.
+- **Where this sits** is optional. Delete it when the PR touches one obvious place.
+- **What to check** is for the reviewer, not the author. One bullet per behaviour to verify, with
+  `file:line` pointers. It is not a file inventory — the Files changed tab already has that.
+- **If the PR does two things, say why they are in one PR.** Better still, split before you start:
+  deciding that up front is far cheaper than unpicking a branch afterwards.
+
+Agents opening PRs with `gh pr create --body` bypass the template entirely, so copy its sections
+across by hand.
+
 ## Before you open a PR
 
 ```bash


### PR DESCRIPTION
## Where this sits

`CONTRIBUTING.md` and `.github/pull_request_template.md` — the two files a contributor reads before their first PR, and the only place the house writing standards can reach a collaborator or a CI-launched agent, since until now they lived in a personal global config on one machine.

## What this changes

The template asked for `What and why` plus a checklist, which is enough for a small PR and leaves a reviewer of a larger one to rebuild the context from the diff. It now has four sections — **Where this sits** (optional), **What this changes**, **What to check**, **Before you merge** — each capped at one paragraph, because a section with no length hint gets padded to look thorough and then goes unread. `CONTRIBUTING.md` gains the writing principles and a section on filling the template in.

## What to check

- `.github/pull_request_template.md` — **What to check** is deliberately not a "changes breakdown". The Files changed tab already lists files, so the section earns its space only by naming behaviours and where they live. This PR body is the shape it's asking for.
- `.github/pull_request_template.md:20` onward — the existing checklist items survive verbatim; `Issue linked` and the ADR prompt are the only additions.
- `CONTRIBUTING.md` — existing headings are left as nouns on purpose. Converting them to assertions would conflict with `docs/comments-pre-existing` and six `feat/stop-*` branches; that's a follow-up once the stop stack lands.

## Before you merge

- [x] `npm run lint`, `npm run test` and `npm run build` pass — docs-only, no code touched
- [x] No exported symbol renamed or deleted
- [x] No diagram source changed
- [x] No UI change

🤖 Generated with [Claude Code](https://claude.com/claude-code)