### PR TITLE
CLAUDE.md names the PR template among the invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,10 @@ Each one has cost someone real time. The reasoning is in `docs/`; this is the sh
   sync effect in `src/hooks/useUserDashboardInput.ts`, or the view stops being shareable.
 - **Bumping `@playwright/test` means regenerating the Linux baselines in the same PR.** A new
   browser build re-renders text.
+- **`gh pr create --body` bypasses the PR template silently.** A repository template only
+  pre-fills the web UI textarea, so `--body` and `--body-file` replace it outright and still exit
+  0. Copy the sections out of [.github/pull_request_template.md](.github/pull_request_template.md)
+  by hand and write them to the standard in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## When you change code, check the docs
 


### PR DESCRIPTION
## What this changes

Adds one bullet to `CLAUDE.md`'s invariants list recording that `gh pr create --body` bypasses the PR template, and pointing at `CONTRIBUTING.md` for the standard. The standard is not restated — "Open the PR with the template filled in" already owns it and stays authoritative.

The four-section template and that CONTRIBUTING section both landed in #241. Neither is reachable from the layer agents actually load: `CLAUDE.md` links `CONTRIBUTING.md` exactly once, under the docs rule, and says nothing about PR descriptions. A repository template only pre-fills the web UI textarea, so `--body` and `--body-file` replace it outright and still exit 0 — the rule was unreachable at precisely the moment it applied.

No PR has been opened here since #241, so this is a structural gap rather than a measured failure. The identical gap in a sibling repo produced three non-compliant PRs out of eight in the week after its template landed, which is what prompted looking here.

## What to check

- [CLAUDE.md:87](CLAUDE.md#L87) — the bullet is a pointer, not a second copy of the standard. If it restates anything `CONTRIBUTING.md` owns, that is the bug; the docs rule in that file says every fact lives in exactly one place.
- It sits in the invariants list, whose preamble says each entry has cost someone real time and that the reasoning lives elsewhere. That is the right shelf for this, but worth a second opinion.

## Before you merge

- [x] `npm run lint`, `npm run test` and `npm run build` pass — lint clean; test and build not re-run, as the change is one Markdown file that no build input reads
- [x] Renamed or deleted an exported symbol? No
- [x] Changed a diagram source? No
- [x] Changed the UI? No

This description was written by copying the template's sections by hand, which is the practice the change is asking for.
